### PR TITLE
Enforce check

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,4 +106,4 @@ Verify admin or member role
 
 Ensure correct signing address
 
-check enforecd and verified,but upload on different brance
+check enforecd and verified,but upload on different branch comment


### PR DESCRIPTION
The implementation prevents re-entrancy attacks because:

State changes are atomic and saved before any external token transfers
Even if a malicious contract re-enters during the token transfer, the state already reflects the completed payout
Subsequent payout attempts will fail with PayoutAlreadyReceived
closes #33 