### PR TITLE
Add 10% tax withholding escrow for interest earnings

### DIFF
--- a/src/auto_rollover.rs
+++ b/src/auto_rollover.rs
@@ -21,6 +21,8 @@ const ROLLOVER_APPROVAL_THRESHOLD_BPS: u32 = 5100;
 
 /// Number of rounds before end to trigger continuity vote
 const ROLLOVER_TRIGGER_ROUNDS_BEFORE_END: u32 = 2;
+/// 10% tax withholding from earned interest
+const TAX_WITHHOLDING_BPS: u32 = 1000;
 
 /// Data key for rollover state per circle
 #[contracttype]
@@ -30,6 +32,8 @@ pub enum RolloverDataKey {
     RolloverVotes(u64),         // Vec of individual vote records
     RolloverPrepared(u64),      // Whether new instance has been prepared
     RolloverVotesCount(u64),    // Count of yes/no votes
+    TaxVault(u64, Address),     // Tax vault by (circle_id, user)
+    TaxVaultTotalWithheld(u64), // Aggregate withheld tax for circle
 }
 
 // --- DATA STRUCTURES ---
@@ -84,6 +88,29 @@ pub struct RolloverPreparation {
     pub members_joined: Vec<Address>,  // Members who confirmed rollover participation
 }
 
+/// Per-user tax vault balance and accounting state for interest withholding.
+#[contracttype]
+#[derive(Clone)]
+pub struct TaxVault {
+    pub circle_id: u64,
+    pub owner: Address,
+    pub withheld_balance: i128,
+    pub total_withheld: i128,
+    pub total_claimed: i128,
+    pub last_withheld_timestamp: u64,
+    pub last_claim_timestamp: u64,
+}
+
+/// Return value of an interest-tax withholding operation.
+#[contracttype]
+#[derive(Clone)]
+pub struct TaxWithholdingResult {
+    pub gross_interest: i128,
+    pub tax_withheld: i128,
+    pub net_interest: i128,
+    pub resulting_tax_vault_balance: i128,
+}
+
 /// Default implementation for RolloverVote
 impl Default for RolloverVote {
     fn default() -> Self {
@@ -117,6 +144,20 @@ impl Default for RolloverPreparation {
             prepared_at: 0,
             is_complete: false,
             members_joined: Vec::new(&env),
+        }
+    }
+}
+
+impl TaxVault {
+    fn new(circle_id: u64, owner: Address) -> Self {
+        Self {
+            circle_id,
+            owner,
+            withheld_balance: 0,
+            total_withheld: 0,
+            total_claimed: 0,
+            last_withheld_timestamp: 0,
+            last_claim_timestamp: 0,
         }
     }
 }
@@ -305,6 +346,99 @@ pub fn get_rollover_preparation(env: &Env, circle_id: u64) -> RolloverPreparatio
     RolloverPreparation::default()
 }
 
+// --- TAX WITHHOLDING ESCROW FUNCTIONS ---
+
+/// Calculates 10% withholding from earned interest and net distributable interest.
+pub fn calculate_interest_tax_withholding(interest_earned: i128) -> (i128, i128) {
+    if interest_earned <= 0 {
+        return (0, interest_earned);
+    }
+
+    let tax_withheld = (interest_earned * TAX_WITHHOLDING_BPS as i128) / 10000;
+    let net_interest = interest_earned - tax_withheld;
+    (tax_withheld, net_interest)
+}
+
+/// Applies automatic tax withholding to interest earnings and credits the user's tax vault.
+pub fn withhold_tax_from_interest(
+    env: &Env,
+    circle_id: u64,
+    user: Address,
+    interest_earned: i128,
+) -> TaxWithholdingResult {
+    let (tax_withheld, net_interest) = calculate_interest_tax_withholding(interest_earned);
+    let key = RolloverDataKey::TaxVault(circle_id, user.clone());
+    let mut vault: TaxVault = env
+        .storage()
+        .instance()
+        .get(&key)
+        .unwrap_or_else(|| TaxVault::new(circle_id, user));
+
+    if tax_withheld > 0 {
+        vault.withheld_balance += tax_withheld;
+        vault.total_withheld += tax_withheld;
+        vault.last_withheld_timestamp = env.ledger().timestamp();
+        env.storage().instance().set(&key, &vault);
+
+        let total_key = RolloverDataKey::TaxVaultTotalWithheld(circle_id);
+        let total_withheld: i128 = env.storage().instance().get(&total_key).unwrap_or(0);
+        env.storage()
+            .instance()
+            .set(&total_key, &(total_withheld + tax_withheld));
+    }
+
+    TaxWithholdingResult {
+        gross_interest: interest_earned,
+        tax_withheld,
+        net_interest,
+        resulting_tax_vault_balance: vault.withheld_balance,
+    }
+}
+
+/// Allows user to claim all withheld tax funds from their tax vault.
+/// This function returns the amount and clears the vault balance.
+pub fn claim_tax_vault(
+    env: &Env,
+    circle_id: u64,
+    user: Address,
+) -> Result<i128, TaxEscrowError> {
+    user.require_auth();
+
+    let key = RolloverDataKey::TaxVault(circle_id, user.clone());
+    let mut vault: TaxVault = env
+        .storage()
+        .instance()
+        .get(&key)
+        .unwrap_or_else(|| TaxVault::new(circle_id, user));
+
+    if vault.withheld_balance <= 0 {
+        return Err(TaxEscrowError::NothingToClaim);
+    }
+
+    let claim_amount = vault.withheld_balance;
+    vault.withheld_balance = 0;
+    vault.total_claimed += claim_amount;
+    vault.last_claim_timestamp = env.ledger().timestamp();
+    env.storage().instance().set(&key, &vault);
+
+    Ok(claim_amount)
+}
+
+/// Reads the user's tax vault state.
+pub fn get_tax_vault(env: &Env, circle_id: u64, user: Address) -> TaxVault {
+    let key = RolloverDataKey::TaxVault(circle_id, user.clone());
+    env.storage()
+        .instance()
+        .get(&key)
+        .unwrap_or_else(|| TaxVault::new(circle_id, user))
+}
+
+/// Reads the aggregate tax withheld for a circle.
+pub fn get_total_tax_withheld(env: &Env, circle_id: u64) -> i128 {
+    let key = RolloverDataKey::TaxVaultTotalWithheld(circle_id);
+    env.storage().instance().get(&key).unwrap_or(0)
+}
+
 // --- ERROR TYPES ---
 
 #[contracttype]
@@ -317,6 +451,13 @@ pub enum RolloverError {
     AlreadyVoted = 4,
     PreparationFailed = 5,
     NotAuthorized = 6,
+}
+
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum TaxEscrowError {
+    NothingToClaim = 1,
 }
 
 #[cfg(test)]
@@ -363,5 +504,52 @@ mod tests {
         assert!(vote.is_passed.is_none());
         assert_eq!(vote.yes_votes, 0);
         assert_eq!(vote.no_votes, 0);
+    }
+
+    #[test]
+    fn test_calculate_interest_tax_withholding() {
+        let (tax, net) = calculate_interest_tax_withholding(100_000_000);
+        assert_eq!(tax, 10_000_000);
+        assert_eq!(net, 90_000_000);
+
+        let (tax_zero, net_zero) = calculate_interest_tax_withholding(0);
+        assert_eq!(tax_zero, 0);
+        assert_eq!(net_zero, 0);
+    }
+
+    #[test]
+    fn test_withhold_tax_from_interest_credits_vault() {
+        let env = Env::default();
+        let user = Address::generate(&env);
+        let circle_id = 42u64;
+
+        let result = withhold_tax_from_interest(&env, circle_id, user.clone(), 50_000_000);
+        assert_eq!(result.tax_withheld, 5_000_000);
+        assert_eq!(result.net_interest, 45_000_000);
+        assert_eq!(result.resulting_tax_vault_balance, 5_000_000);
+
+        let vault = get_tax_vault(&env, circle_id, user);
+        assert_eq!(vault.withheld_balance, 5_000_000);
+        assert_eq!(vault.total_withheld, 5_000_000);
+        assert_eq!(get_total_tax_withheld(&env, circle_id), 5_000_000);
+    }
+
+    #[test]
+    fn test_claim_tax_vault() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let user = Address::generate(&env);
+        let circle_id = 7u64;
+
+        withhold_tax_from_interest(&env, circle_id, user.clone(), 10_000_000);
+        let claimed = claim_tax_vault(&env, circle_id, user.clone()).unwrap();
+        assert_eq!(claimed, 1_000_000);
+
+        let vault = get_tax_vault(&env, circle_id, user.clone());
+        assert_eq!(vault.withheld_balance, 0);
+        assert_eq!(vault.total_claimed, 1_000_000);
+
+        let nothing_left = claim_tax_vault(&env, circle_id, user);
+        assert_eq!(nothing_left, Err(TaxEscrowError::NothingToClaim));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 use soroban_sdk::{contract, contracttype, contractimpl, Address, Env, Vec, Symbol, token, testutils::{Address as TestAddress, Arbitrary as TestArbitrary}, arbitrary::{Arbitrary, Unstructured}};
 
 // --- DATA STRUCTURES ---
+const TAX_WITHHOLDING_BPS: u64 = 1000; // 10%
 
 #[contracttype]
 #[derive(Clone)]
@@ -21,6 +22,14 @@ pub enum DataKey {
     // #228: Governance
     Stake(Address),
     GlobalFeeBP, // Basis points
+    // Tax Withholding Escrow for Interest Earnings
+    TaxVault(u64, Address),          // circle_id, user
+    TaxWithheldTotal(u64),           // circle_id
+    TaxClaimedTotal(u64),            // circle_id
+    TaxWithheldByUser(u64, Address), // circle_id, user
+    TaxClaimedByUser(u64, Address),  // circle_id, user
+    GrossInterestTotal(u64),         // circle_id
+    GrossInterestByUser(u64, Address), // circle_id, user
 }
 
 #[contracttype]
@@ -58,6 +67,20 @@ pub struct CircleInfo {
     pub cycle_duration: u64, // Duration of each payment cycle in seconds
 }
 
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct TaxReport {
+    pub circle_id: u64,
+    pub user: Address,
+    pub gross_interest_total_for_circle: u64,
+    pub gross_interest_for_user: u64,
+    pub total_tax_withheld_for_circle: u64,
+    pub total_tax_withheld_for_user: u64,
+    pub total_tax_claimed_for_circle: u64,
+    pub total_tax_claimed_for_user: u64,
+    pub current_tax_vault_balance: u64,
+}
+
 // --- CONTRACT TRAIT ---
 
 pub trait SoroSusuTrait {
@@ -85,6 +108,28 @@ pub trait SoroSusuTrait {
     fn stake_xlm(env: Env, user: Address, xlm_token: Address, amount: u64);
     fn unstake_xlm(env: Env, user: Address, xlm_token: Address, amount: u64);
     fn update_global_fee(env: Env, admin: Address, new_fee: u32);
+
+    // Tax Withholding Escrow for Interest Earnings
+    fn process_interest_earning(env: Env, operator: Address, circle_id: u64, beneficiary: Address, gross_interest: u64) -> (u64, u64);
+    fn claim_tax_vault(env: Env, user: Address, circle_id: u64) -> u64;
+    fn get_tax_vault_balance(env: Env, user: Address, circle_id: u64) -> u64;
+    fn get_total_tax_withheld(env: Env, circle_id: u64) -> u64;
+    fn get_total_tax_claimed(env: Env, circle_id: u64) -> u64;
+    fn get_tax_report(env: Env, user: Address, circle_id: u64) -> TaxReport;
+}
+
+fn checked_add_u64(a: u64, b: u64, context: &str) -> u64 {
+    a.checked_add(b).unwrap_or_else(|| panic!("{}", context))
+}
+
+fn calculate_interest_tax_split(gross_interest: u64) -> (u64, u64) {
+    if gross_interest == 0 {
+        return (0, 0);
+    }
+
+    let tax_withheld = (gross_interest * TAX_WITHHOLDING_BPS) / 10_000;
+    let net_interest = gross_interest - tax_withheld;
+    (tax_withheld, net_interest)
 }
 
 // --- IMPLEMENTATION ---
@@ -396,6 +441,117 @@ impl SoroSusuTrait for SoroSusu {
         }
 
         env.storage().instance().set(&DataKey::GlobalFeeBP, &new_fee);
+    }
+
+    fn process_interest_earning(env: Env, operator: Address, circle_id: u64, beneficiary: Address, gross_interest: u64) -> (u64, u64) {
+        operator.require_auth();
+        if gross_interest == 0 {
+            panic!("Gross interest must be > 0");
+        }
+
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if operator != stored_admin {
+            panic!("Only admin can process interest earnings");
+        }
+
+        // Ensure circle exists and discover token.
+        let circle: CircleInfo = env.storage().instance().get(&DataKey::Circle(circle_id))
+            .unwrap_or_else(|| panic!("Circle not found"));
+
+        let (tax_withheld, net_interest) = calculate_interest_tax_split(gross_interest);
+        let token_client = token::Client::new(&env, &circle.token);
+
+        // Interest inflow is deposited to contract first, then net is paid to beneficiary.
+        token_client.transfer(&operator, &env.current_contract_address(), &gross_interest);
+        if net_interest > 0 {
+            token_client.transfer(&env.current_contract_address(), &beneficiary, &net_interest);
+        }
+
+        // Update per-user tax vault and accounting totals.
+        let vault_key = DataKey::TaxVault(circle_id, beneficiary.clone());
+        let existing_vault: u64 = env.storage().instance().get(&vault_key).unwrap_or(0);
+        let updated_vault = checked_add_u64(existing_vault, tax_withheld, "Tax vault overflow");
+        env.storage().instance().set(&vault_key, &updated_vault);
+
+        let total_withheld_key = DataKey::TaxWithheldTotal(circle_id);
+        let total_withheld: u64 = env.storage().instance().get(&total_withheld_key).unwrap_or(0);
+        env.storage().instance().set(&total_withheld_key, &checked_add_u64(total_withheld, tax_withheld, "Total tax withheld overflow"));
+
+        let user_withheld_key = DataKey::TaxWithheldByUser(circle_id, beneficiary.clone());
+        let user_withheld: u64 = env.storage().instance().get(&user_withheld_key).unwrap_or(0);
+        env.storage().instance().set(&user_withheld_key, &checked_add_u64(user_withheld, tax_withheld, "User tax withheld overflow"));
+
+        let gross_total_key = DataKey::GrossInterestTotal(circle_id);
+        let gross_total: u64 = env.storage().instance().get(&gross_total_key).unwrap_or(0);
+        env.storage().instance().set(&gross_total_key, &checked_add_u64(gross_total, gross_interest, "Gross interest total overflow"));
+
+        let user_gross_key = DataKey::GrossInterestByUser(circle_id, beneficiary.clone());
+        let user_gross: u64 = env.storage().instance().get(&user_gross_key).unwrap_or(0);
+        env.storage().instance().set(&user_gross_key, &checked_add_u64(user_gross, gross_interest, "User gross interest overflow"));
+
+        env.events().publish(
+            (Symbol::new(&env, "tax_withheld"), circle_id, beneficiary.clone()),
+            (gross_interest, tax_withheld, net_interest, updated_vault),
+        );
+
+        (tax_withheld, net_interest)
+    }
+
+    fn claim_tax_vault(env: Env, user: Address, circle_id: u64) -> u64 {
+        user.require_auth();
+
+        let circle: CircleInfo = env.storage().instance().get(&DataKey::Circle(circle_id))
+            .unwrap_or_else(|| panic!("Circle not found"));
+        let vault_key = DataKey::TaxVault(circle_id, user.clone());
+        let claim_amount: u64 = env.storage().instance().get(&vault_key).unwrap_or(0);
+        if claim_amount == 0 {
+            panic!("Nothing to claim");
+        }
+
+        let token_client = token::Client::new(&env, &circle.token);
+        token_client.transfer(&env.current_contract_address(), &user, &claim_amount);
+        env.storage().instance().set(&vault_key, &0u64);
+
+        let total_claimed_key = DataKey::TaxClaimedTotal(circle_id);
+        let total_claimed: u64 = env.storage().instance().get(&total_claimed_key).unwrap_or(0);
+        env.storage().instance().set(&total_claimed_key, &checked_add_u64(total_claimed, claim_amount, "Total tax claimed overflow"));
+
+        let user_claimed_key = DataKey::TaxClaimedByUser(circle_id, user.clone());
+        let user_claimed: u64 = env.storage().instance().get(&user_claimed_key).unwrap_or(0);
+        env.storage().instance().set(&user_claimed_key, &checked_add_u64(user_claimed, claim_amount, "User tax claimed overflow"));
+
+        env.events().publish(
+            (Symbol::new(&env, "tax_claimed"), circle_id, user.clone()),
+            claim_amount,
+        );
+
+        claim_amount
+    }
+
+    fn get_tax_vault_balance(env: Env, user: Address, circle_id: u64) -> u64 {
+        env.storage().instance().get(&DataKey::TaxVault(circle_id, user)).unwrap_or(0)
+    }
+
+    fn get_total_tax_withheld(env: Env, circle_id: u64) -> u64 {
+        env.storage().instance().get(&DataKey::TaxWithheldTotal(circle_id)).unwrap_or(0)
+    }
+
+    fn get_total_tax_claimed(env: Env, circle_id: u64) -> u64 {
+        env.storage().instance().get(&DataKey::TaxClaimedTotal(circle_id)).unwrap_or(0)
+    }
+
+    fn get_tax_report(env: Env, user: Address, circle_id: u64) -> TaxReport {
+        TaxReport {
+            circle_id,
+            user: user.clone(),
+            gross_interest_total_for_circle: env.storage().instance().get(&DataKey::GrossInterestTotal(circle_id)).unwrap_or(0),
+            gross_interest_for_user: env.storage().instance().get(&DataKey::GrossInterestByUser(circle_id, user.clone())).unwrap_or(0),
+            total_tax_withheld_for_circle: env.storage().instance().get(&DataKey::TaxWithheldTotal(circle_id)).unwrap_or(0),
+            total_tax_withheld_for_user: env.storage().instance().get(&DataKey::TaxWithheldByUser(circle_id, user.clone())).unwrap_or(0),
+            total_tax_claimed_for_circle: env.storage().instance().get(&DataKey::TaxClaimedTotal(circle_id)).unwrap_or(0),
+            total_tax_claimed_for_user: env.storage().instance().get(&DataKey::TaxClaimedByUser(circle_id, user.clone())).unwrap_or(0),
+            current_tax_vault_balance: env.storage().instance().get(&DataKey::TaxVault(circle_id, user)).unwrap_or(0),
+        }
     }
 }
 


### PR DESCRIPTION
closes #214 Build Tax_Withholding_Escrow_for_Interest_Earnings

**Summary**
Implements Tax_Withholding_Escrow_for_Interest_Earnings by adding automatic 10% tax withholding on interest, storing withheld amounts in a per-user tax vault, and enabling user tax-vault claims.

**What Changed**
- Added tax escrow storage keys and accounting in src/lib.rs.
- Added process_interest_earning to split gross interest into:
   - 10% withheld tax
   - 90% net payout
- Added claim_tax_vault with token transfer from contract to user.
- Added reporting/read APIs:
   - get_tax_vault_balance
   - get_total_tax_withheld
   - get_total_tax_claimed
   - get_tax_report

- Added audit/compliance events:
   - tax_withheld
   - tax_claimed
- Added supporting tax escrow logic/tests in src/auto_rollover.rs.

**Why**
This introduces compliance-as-code for taxable interest earnings, making payouts tax-friendly by automatically separating tax obligations into a claimable vault.