### PR TITLE
feat: Implement an in-app chat metadata anchoring system

### DIFF
--- a/src/chat_metadata.rs
+++ b/src/chat_metadata.rs
@@ -1,0 +1,162 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String, Symbol, Vec};
+
+const CHAT_HASH_WINDOW_SECS: u64 = 24 * 60 * 60;
+const MAX_CID_LEN: u32 = 128;
+const MIN_CID_LEN: u32 = 10;
+const MAX_HISTORY_ENTRIES: u32 = 3;
+
+#[contracttype]
+#[derive(Clone)]
+pub enum ChatMetadataDataKey {
+    Admin,
+    GroupAdmin(u64),
+    GroupChatRecord(u64),
+    GroupChatHistory(u64),
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct ChatHashRecord {
+    pub cid: String,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct ChatHashRecordedEvent {
+    pub group_id: u64,
+    pub cid: String,
+    pub timestamp: u64,
+}
+
+#[contract]
+pub struct ChatMetadata;
+
+#[contractimpl]
+impl ChatMetadata {
+    pub fn init(env: Env, admin: Address) {
+        env.storage().instance().set(&ChatMetadataDataKey::Admin, &admin);
+    }
+
+    pub fn authorize_group_admin(
+        env: Env,
+        admin: Address,
+        group_id: u64,
+        group_admin: Address,
+    ) {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&ChatMetadataDataKey::Admin)
+            .expect("Contract not initialized");
+        if admin != stored_admin {
+            panic!("Unauthorized");
+        }
+        env.storage()
+            .instance()
+            .set(&ChatMetadataDataKey::GroupAdmin(group_id), &group_admin);
+    }
+
+    pub fn record_chat_hash(env: Env, signer: Address, group_id: u64, cid: String) {
+        signer.require_auth();
+        let current_time = env.ledger().timestamp();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&ChatMetadataDataKey::Admin)
+            .expect("Contract not initialized");
+
+        let group_admin: Option<Address> = env
+            .storage()
+            .instance()
+            .get(&ChatMetadataDataKey::GroupAdmin(group_id));
+
+        let authorized = match group_admin {
+            Some(admin_addr) => signer == admin_addr || signer == stored_admin,
+            None => signer == stored_admin,
+        };
+        if !authorized {
+            panic!("Unauthorized");
+        }
+
+        Self::validate_cid(&cid);
+
+        if let Some(existing_record) = env
+            .storage()
+            .instance()
+            .get::<ChatMetadataDataKey, ChatHashRecord>(&ChatMetadataDataKey::GroupChatRecord(group_id))
+        {
+            if current_time < existing_record.timestamp + CHAT_HASH_WINDOW_SECS {
+                panic!("Chat hash already recorded within 24 hours");
+            }
+        }
+
+        let record = ChatHashRecord {
+            cid: cid.clone(),
+            timestamp: current_time,
+        };
+
+        env.storage()
+            .instance()
+            .set(&ChatMetadataDataKey::GroupChatRecord(group_id), &record);
+
+        let mut history: Vec<ChatHashRecord> = env
+            .storage()
+            .instance()
+            .get(&ChatMetadataDataKey::GroupChatHistory(group_id))
+            .unwrap_or_else(|| Vec::new(&env));
+        history.push_back(record.clone());
+
+        if history.len() > MAX_HISTORY_ENTRIES {
+            let mut trimmed = Vec::new(&env);
+            let start = history.len() - MAX_HISTORY_ENTRIES;
+            for i in start..history.len() {
+                trimmed.push_back(history.get_unchecked(i));
+            }
+            history = trimmed;
+        }
+
+        env.storage()
+            .instance()
+            .set(&ChatMetadataDataKey::GroupChatHistory(group_id), &history);
+
+        env.events().publish(
+            (Symbol::new(&env, "ChatHashRecorded"),),
+            ChatHashRecordedEvent {
+                group_id,
+                cid,
+                timestamp: current_time,
+            },
+        );
+    }
+
+    pub fn get_latest_chat_hash(env: Env, group_id: u64) -> Option<ChatHashRecord> {
+        env.storage()
+            .instance()
+            .get(&ChatMetadataDataKey::GroupChatRecord(group_id))
+    }
+
+    pub fn get_chat_hash_history(env: Env, group_id: u64) -> Vec<ChatHashRecord> {
+        env.storage()
+            .instance()
+            .get(&ChatMetadataDataKey::GroupChatHistory(group_id))
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+}
+
+impl ChatMetadata {
+    fn validate_cid(cid: &String) {
+        let len = cid.len();
+        if len < MIN_CID_LEN || len > MAX_CID_LEN {
+            panic!("Invalid CID format");
+        }
+        for &byte in cid.as_bytes().iter() {
+            if byte <= 0x20 || byte == 0x7f {
+                panic!("Invalid CID format");
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use soroban_sdk::{
     Symbol, Vec,
 };
 
+pub mod chat_metadata;
 pub mod dispute;
 pub mod yield_allocation_voting;
 pub mod yield_strategy_trait;

--- a/tests/chat_metadata_test.rs
+++ b/tests/chat_metadata_test.rs
@@ -1,0 +1,105 @@
+#![cfg(test)]
+
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{Address, Env, String, Vec};
+use sorosusu_contracts::chat_metadata::ChatMetadataClient;
+use sorosusu_contracts::chat_metadata::ChatMetadata;
+
+fn setup_contract() -> (Env, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let group_admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, ChatMetadata);
+    let client = ChatMetadataClient::new(&env, &contract_id);
+    client.init(&admin);
+    client.authorize_group_admin(&admin, &1u64, &group_admin);
+    (env, admin, group_admin, contract_id)
+}
+
+#[test]
+fn test_record_chat_hash_success() {
+    let (env, _admin, group_admin, contract_id) = setup_contract();
+    let client = ChatMetadataClient::new(&env, &contract_id);
+    let cid = String::from_slice(&env, "QmYwAPJzv5CZsnAzt8auVTLhRBrY2xYK27n5aLqGvFootd");
+
+    client.record_chat_hash(&group_admin, &1u64, &cid.clone());
+    let record = client.get_latest_chat_hash(&1u64).expect("record missing");
+
+    assert_eq!(record.cid, cid);
+    assert_eq!(record.timestamp, env.ledger().timestamp());
+}
+
+#[test]
+fn test_reject_within_24h_window() {
+    let (env, _admin, group_admin, contract_id) = setup_contract();
+    let client = ChatMetadataClient::new(&env, &contract_id);
+    let cid1 = String::from_slice(&env, "QmYwAPJzv5CZsnAzt8auVTLhRBrY2xYK27n5aLqGvFootd");
+    let cid2 = String::from_slice(&env, "QmZxoqJzv5CZwqAzt8auVTLhRBrY2xYK27n5aLqGvFooXy");
+
+    client.record_chat_hash(&group_admin, &1u64, &cid1);
+    let result = std::panic::catch_unwind(|| {
+        client.record_chat_hash(&group_admin, &1u64, &cid2);
+    });
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_authorization_enforced() {
+    let (env, _admin, _group_admin, contract_id) = setup_contract();
+    let client = ChatMetadataClient::new(&env, &contract_id);
+    let unauthorized = Address::generate(&env);
+    let cid = String::from_slice(&env, "QmYwAPJzv5CZsnAzt8auVTLhRBrY2xYK27n5aLqGvFootd");
+
+    let result = std::panic::catch_unwind(|| {
+        client.record_chat_hash(&unauthorized, &1u64, &cid);
+    });
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_invalid_cid_format() {
+    let (env, _admin, group_admin, contract_id) = setup_contract();
+    let client = ChatMetadataClient::new(&env, &contract_id);
+    let invalid_cid = String::from_slice(&env, "   ");
+
+    let result = std::panic::catch_unwind(|| {
+        client.record_chat_hash(&group_admin, &1u64, &invalid_cid);
+    });
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_multiple_groups_independent_windows() {
+    let (env, _admin, group_admin, contract_id) = setup_contract();
+    let client = ChatMetadataClient::new(&env, &contract_id);
+    let cid1 = String::from_slice(&env, "QmYwAPJzv5CZsnAzt8auVTLhRBrY2xYK27n5aLqGvFootd");
+    let cid2 = String::from_slice(&env, "QmZxoqJzv5CZwqAzt8auVTLhRBrY2xYK27n5aLqGvFooXy");
+
+    client.record_chat_hash(&group_admin, &1u64, &cid1);
+    client.record_chat_hash(&group_admin, &2u64, &cid2);
+
+    let record1 = client.get_latest_chat_hash(&1u64).expect("group1 missing");
+    let record2 = client.get_latest_chat_hash(&2u64).expect("group2 missing");
+
+    assert_eq!(record1.cid, cid1);
+    assert_eq!(record2.cid, cid2);
+}
+
+#[test]
+fn test_exactly_24h_boundary_allowed() {
+    let (env, _admin, group_admin, contract_id) = setup_contract();
+    let client = ChatMetadataClient::new(&env, &contract_id);
+    let cid1 = String::from_slice(&env, "QmYwAPJzv5CZsnAzt8auVTLhRBrY2xYK27n5aLqGvFootd");
+    let cid2 = String::from_slice(&env, "QmZxoqJzv5CZwqAzt8auVTLhRBrY2xYK27n5aLqGvFooXy");
+
+    client.record_chat_hash(&group_admin, &1u64, &cid1);
+    env.ledger().set_timestamp(env.ledger().timestamp() + 24 * 60 * 60);
+    client.record_chat_hash(&group_admin, &1u64, &cid2);
+
+    let record = client.get_latest_chat_hash(&1u64).expect("latest missing");
+    assert_eq!(record.cid, cid2);
+}


### PR DESCRIPTION
Closes #331

## Summary
Implemented an in-app chat metadata anchoring system that records IPFS CIDs of encrypted group chat logs on-chain. This provides a tamper-proof, timestamped “Proof of Consensus” mechanism for dispute resolution without storing actual chat data on-chain.

## Key Features
- Added `record_chat_hash(group_id, cid)` function to anchor chat metadata
- Enforced 24-hour replay protection per group using ledger timestamps
- Implemented access control (group admin with optional global admin fallback)
- Added `ChatHashRecorded` event for verifiable audit trail
- Introduced minimal and bounded storage:
  - latest record per group
  - optional history (last 3 entries)
- Added CID validation guard to prevent malformed inputs

## Implementation Details
- Uses `ledger().timestamp()` for reliable, on-chain timekeeping
- Stores only CID + timestamp to keep on-chain footprint minimal
- Prevents overwriting within the same 24-hour window
- Supports multiple groups with isolated storage keys
- History is bound to avoid storage bloat

## Testing
Added unit tests covering:
- successful recording flow
- rejection within 24-hour window
- access control enforcement
- timestamp correctness
- invalid CID handling
- independent group behavior
- exact 24-hour boundary condition

## Design Notes
- Follows “off-chain data, on-chain proof” pattern for efficiency
- Events provide an additional immutable audit layer
- Storage design balances auditability with gas efficiency