### PR TITLE
Reputation-NFT, Role-Check and Update batch member

### DIFF
--- a/MOBILE_API.md
+++ b/MOBILE_API.md
@@ -395,6 +395,20 @@ Fired when a Soulbound Token credential is issued to a member.
 
 ---
 
+### Event: `ReputationBadgeUpdated`
+
+Fired when a reputation SBT is minted or its dynamic metadata changes.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| topic[0] | Symbol | `"ReputationBadgeUpdated"` |
+| topic[1] | u128 | SBT token ID |
+| data[0] | Address | Badge owner |
+| data[1] | SbtStatus | Current status or tier title |
+| data[2] | String | Updated IPFS metadata URI |
+
+---
+
 ### Event: `MissingTrustline`
 
 Fired when a yield payout is held because the recipient lacks a trustline for the circle token.

--- a/MOBILE_API.md
+++ b/MOBILE_API.md
@@ -19,6 +19,7 @@ This document is the primary reference for developers building a SoroSusu-compat
    - [late_contribution](#late_contribution)
    - [get_circle](#get_circle)
    - [get_member](#get_member)
+   - [is_reputable_user](#is_reputable_user)
    - [get_current_recipient](#get_current_recipient)
    - [get_user_summary](#get_user_summary)
 4. [Event Schemas for Push Notifications](#event-schemas-for-push-notifications)
@@ -274,6 +275,23 @@ Member fields:
   status             : MemberStatus  // Active | Defaulted | Exited
   buddy              : Option<Address>
   guarantor          : Option<Address>
+```
+
+---
+
+### `is_reputable_user`
+
+Read-only Reputation-as-a-Service adapter for partner protocols. Returns only a
+boolean and does not expose circle, group, contribution, or vouching details.
+Missing or archived reputation data returns `false`.
+
+```
+Function : is_reputable_user
+Arguments:
+  [0] user : Address
+Returns  : bool  // true only when RI > 900 and defaults_count == 0
+Auth     : none
+Events   : none
 ```
 
 ---

--- a/MOBILE_API.md
+++ b/MOBILE_API.md
@@ -136,23 +136,25 @@ xdr.ScVal.scvVoid()
 
 ### `deposit`
 
-Submits the user's contribution for the current round.
+Submits the user's contribution for one or more rounds in a single ledger transaction.
 
 ```
 Function : deposit
 Arguments:
   [0] user      : Address
   [1] circle_id : u64
+  [2] rounds    : u32
 Returns  : void
 Auth     : user must sign
-Notes    : The token transfer is executed internally. The user must have
-           approved the contract to spend `amount` tokens beforehand.
+Notes    : The token transfer and member contribution-history update are
+           executed atomically. The user must have approved the contract to
+           spend `amount * rounds` tokens beforehand.
 ```
 
 **Pre-approval (SEP-41 `approve`):**
 
 ```js
-// Approve the SoroSusu contract to pull `amount` from the user's balance.
+// Approve the SoroSusu contract to pull `amount * rounds` from the user's balance.
 const approveOp = tokenContract.call(
   "approve",
   nativeToScVal(userAddress, { type: "address" }),

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Sets user's payout preference for a circle (Direct Token vs Direct-to-Bank).
 #### `get_payout_preference(env: Env, user: Address, circle_id: u64) -> UserBankPreference`
 Retrieves user's payout preference for a circle.
 
+#### `is_reputable_user(env: Env, user: Address) -> bool`
+Read-only partner adapter that returns true only when the user's Reliability Index is greater than 900 and they have zero defaults. It emits no events and reveals no private group membership data.
+
 #### `deposit_for_user(env: Env, anchor_address: Address, user_address: Address, circle_id: u64, amount: u64, token: Address, fiat_reference: Symbol)`
 Deposits funds on behalf of a user via an anchor (for SEP-24 integration).
 
@@ -176,6 +179,9 @@ A specialized voting mechanism to grant extensions to members in distress, preve
 ## Analytics & Reputation Engines
 ### Credit Score Oracle
 Integrates on-chain and off-chain data to calculate a "DeFi Credit Score" based on contribution history.
+
+### Reputation-as-a-Service Adapter
+Partner protocols can call `is_reputable_user(address)` as a high-frequency VIP gate for under-collateralized lending, fee discounts, or other premium DeFi features. Archived or missing reputation records resolve to `false`.
 
 ### Reliability Index (RI) Whitepaper
 Detailed technical documentation is available in `RELIABILITY_INDEX_WHITEPAPER.md`, explaining how the RI is calculated, how fees are discounted, and how inactivity decay and identity gating are enforced.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2563,7 +2563,7 @@ impl SoroSusuTrait for SoroSusu {
         let credential = SoroSusuCredential {
             token_id,
             user: user.clone(),
-            status,
+            status: status.clone(),
             reputation_score,
             metadata_uri: String::from_str(env, "ipfs://sorosusu-sbt-metadata"),
             issue_date: env.ledger().timestamp(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ pub mod juror_selection;
 pub mod passkey_auth;
 // Issue #380: Hierarchical Susu-Aggregation for Institutional Lending
 pub mod aggregate_credit;
+// Reputation-as-a-Service adapter for partner protocol VIP gates.
+pub mod reliability_oracle;
 
 // Issue #321: Maximum cycle duration cap (2 years in seconds) to prevent
 // integer overflow exploits and unbounded storage accumulation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,8 +391,8 @@ pub trait SoroSusuTrait {
     // Join an existing circle
     fn join_circle(env: Env, user: Address, circle_id: u64);
 
-    // Make a deposit (Pay your weekly/monthly due)
-    fn deposit(env: Env, user: Address, circle_id: u64, amount: u64);
+    // Make a batch deposit for one or more rounds.
+    fn deposit(env: Env, user: Address, circle_id: u64, rounds: u32);
 
     // Late contribution with fee (pay after deadline but within grace period)
     fn late_contribution(env: Env, user: Address, circle_id: u64);
@@ -1274,8 +1274,8 @@ pub trait SoroSusuTrait {
     // Join an existing circle
     fn join_circle(env: Env, user: Address, circle_id: u64, shares: u32, guarantor: Option<Address>);
 
-    // Make a deposit (Pay your weekly/monthly due)
-    fn deposit(env: Env, user: Address, circle_id: u64);
+    // Make a batch deposit for one or more rounds.
+    fn deposit(env: Env, user: Address, circle_id: u64, rounds: u32);
 
     // NEW: Gas buffer management functions
     fn fund_gas_buffer(env: Env, circle_id: u64, amount: i128);
@@ -2031,7 +2031,7 @@ impl SoroSusuTrait for SoroSusu {
         env.storage().instance().set(&DataKey::Circle(circle_id), &circle);
     }
 
-    /// Submits the caller's contribution for the current round.
+    /// Submits the caller's contribution for one or more rounds.
     ///
     /// # Parameters
     /// - `user`: Address making the deposit; must sign the transaction.
@@ -2039,18 +2039,53 @@ impl SoroSusuTrait for SoroSusu {
     ///
     /// # Security
     /// The caller must have pre-approved the SoroSusu contract to transfer
-    /// `circle.contribution_amount` tokens on their behalf (SEP-41 `approve`).
-    /// The token transfer is executed atomically within this call.
+    /// `circle.contribution_amount * rounds` tokens on their behalf
+    /// (SEP-41 `approve`). The token transfer and contribution-history update
+    /// are executed atomically within this call.
     ///
     /// # Panics
     /// - `"Circle not found"` — `circle_id` does not exist.
-    fn deposit(env: Env, user: Address, circle_id: u64) {
+    fn deposit(env: Env, user: Address, circle_id: u64, rounds: u32) {
         user.require_auth();
-        let circle: CircleInfo = env.storage().instance()
+        if rounds == 0 {
+            panic!("Rounds must be greater than zero");
+        }
+
+        let mut circle: CircleInfo = env.storage().instance()
             .get(&DataKey::Circle(circle_id))
             .unwrap_or_else(|| panic!("Circle not found"));
+
+        let member_key = DataKey::Member(user.clone());
+        let mut member: Member = env.storage().instance()
+            .get(&member_key)
+            .unwrap_or_else(|| panic!("Member not found"));
+
+        if member.status != MemberStatus::Active {
+            panic!("Member not active");
+        }
+
+        let current_time = env.ledger().timestamp();
+        let rounds_i128 = rounds as i128;
+        let total_contribution = circle.contribution_amount
+            .checked_mul(rounds_i128)
+            .unwrap_or_else(|| panic!("Contribution overflow"));
+
         let token_client = soroban_sdk::token::Client::new(&env, &circle.token);
-        token_client.transfer(&user, &env.current_contract_address(), &circle.contribution_amount);
+        token_client.transfer(&user, &env.current_contract_address(), &total_contribution);
+
+        member.contribution_count = member.contribution_count
+            .checked_add(rounds)
+            .unwrap_or_else(|| panic!("Contribution count overflow"));
+        member.last_contribution_time = current_time;
+
+        let contribution_bit = 1u64
+            .checked_shl(member.index)
+            .unwrap_or_else(|| panic!("Member index overflow"));
+        circle.contribution_bitmap |= contribution_bit;
+
+        env.storage().instance().set(&member_key, &member);
+        env.storage().instance().set(&DataKey::Circle(circle_id), &circle);
+        env.storage().instance().set(&DataKey::Deposit(circle_id, user), &true);
     }
 
 

--- a/src/reliability_oracle.rs
+++ b/src/reliability_oracle.rs
@@ -4,9 +4,7 @@
 // read_reputation() aggregates on-chain member behaviour (contribution history,
 // default record, vouching activity) into a single portable proof struct.
 
-#![no_std]
-
-use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env};
 
 // --- CONSTANTS ---
 
@@ -22,13 +20,21 @@ const RI_TIER_GOOD: u32 = 650;
 /// RI score considered "fair" — minimum for most integrations
 const RI_TIER_FAIR: u32 = 400;
 
+/// VIP partner threshold: callers qualify only when RI is strictly greater
+/// than this value and the account has no recorded defaults.
+pub const REPUTABLE_USER_RI_THRESHOLD: u32 = 900;
+
+/// Maximum CPU instructions accepted by the adapter benchmark.
+pub const REPUTABLE_USER_CPU_BUDGET: u64 = 5_000;
+
 // --- DATA KEYS ---
 
 #[contracttype]
 #[derive(Clone)]
 pub enum OracleDataKey {
-    MemberReputation(Address),   // ReputationRecord per member
-    ProofNonce(Address),         // Monotonically increasing nonce per address
+    MemberReputation(Address), // ReputationRecord per member
+    ProofNonce(Address),       // Monotonically increasing nonce per address
+    ReputableUser(Address),    // Derived VIP gate for cheap partner queries
 }
 
 // --- DATA STRUCTURES ---
@@ -67,7 +73,7 @@ pub struct ReputationProof {
     pub member: Address,
     pub ri_score: u32,
     pub tier: ReputationTier,
-    pub on_time_rate_bps: u32,    // (on_time / total) * 10_000
+    pub on_time_rate_bps: u32, // (on_time / total) * 10_000
     pub defaults_count: u32,
     pub circles_participated: u32,
     pub vouches_given: u32,
@@ -75,6 +81,10 @@ pub struct ReputationProof {
     pub generated_at: u64,
     pub nonce: u32,
 }
+
+/// Minimal public adapter for high-frequency partner queries.
+#[contract]
+pub struct SoroSusuReputationAdapter;
 
 // --- HELPERS ---
 
@@ -88,6 +98,10 @@ fn score_to_tier(score: u32) -> ReputationTier {
     } else {
         ReputationTier::Poor
     }
+}
+
+fn check_reputable_record(record: &ReputationRecord) -> bool {
+    record.ri_score > REPUTABLE_USER_RI_THRESHOLD && record.defaults_count == 0
 }
 
 // --- FUNCTIONS ---
@@ -119,9 +133,26 @@ pub fn update_reputation(
 
     env.storage()
         .instance()
-        .set(&OracleDataKey::MemberReputation(member), &record);
+        .set(&OracleDataKey::MemberReputation(member.clone()), &record);
+
+    let gate_key = OracleDataKey::ReputableUser(member);
+    if check_reputable_record(&record) {
+        env.storage().instance().set(&gate_key, &true);
+    } else {
+        env.storage().instance().remove(&gate_key);
+    }
 
     record
+}
+
+/// Archive a user's reputation data and its derived partner-query gate.
+pub fn archive_reputation(env: &Env, user: Address) {
+    env.storage()
+        .instance()
+        .remove(&OracleDataKey::MemberReputation(user.clone()));
+    env.storage()
+        .instance()
+        .remove(&OracleDataKey::ReputableUser(user));
 }
 
 /// Public oracle entrypoint: returns a standardised ReputationProof for a given address.
@@ -161,11 +192,32 @@ pub fn read_reputation(env: &Env, user: Address) -> Option<ReputationProof> {
     Some(proof)
 }
 
+/// Standardized read-only VIP adapter for partner protocols.
+///
+/// Returns true only when the user's derived reputation gate exists. The gate
+/// is updated atomically with the user's RI/default record, so this performs a
+/// single key-existence check, emits no events, and intentionally avoids
+/// returning group, circle, contribution, or vouching details. Missing or
+/// archived reputation data resolves to false.
+pub fn is_reputable_user(env: &Env, user: Address) -> bool {
+    env.storage()
+        .instance()
+        .has(&OracleDataKey::ReputableUser(user))
+}
+
 /// Check whether a given address meets a minimum RI threshold.
 /// Convenience wrapper for integrations that only need a boolean gate.
 pub fn meets_reputation_threshold(env: &Env, user: Address, min_ri: u32) -> bool {
     match read_reputation(env, user) {
         Some(proof) => proof.ri_score >= min_ri,
         None => false,
+    }
+}
+
+#[contractimpl]
+impl SoroSusuReputationAdapter {
+    /// Cross-contract entrypoint for Reputation-as-a-Service integrations.
+    pub fn is_reputable_user(env: Env, user: Address) -> bool {
+        is_reputable_user(&env, user)
     }
 }

--- a/src/sbt_minter.rs
+++ b/src/sbt_minter.rs
@@ -1,11 +1,25 @@
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short,
-    Address, Env, String,
+    contract, contractimpl, contracttype, symbol_short, Address, Env, String, Symbol,
 };
 
-use crate::DataKey;
-
 // --- SOROSUSU SOULBOUND TOKEN (SBT) SYSTEM ---
+
+const MIN_REPUTATION_BADGE_CYCLES: u32 = 12;
+const DEFAULT_RELIABILITY_SCORE: u32 = 5_000;
+const DEFAULT_SOCIAL_CAPITAL_SCORE: u32 = 5_000;
+
+#[derive(Clone)]
+#[contracttype]
+enum SbtDataKey {
+    Admin,
+    MilestoneCount,
+    CredentialCount,
+    Milestone(u64),
+    Credential(u128),
+    UserCredential(Address),
+    UserReputation(Address),
+    CycleAward(Address, u64, u32),
+}
 
 #[derive(Clone, Debug, PartialEq)]
 #[contracttype]
@@ -15,6 +29,9 @@ pub enum SbtStatus {
     Guardian,
     Luminary,
     SusuLegend,
+    Delinquent,
+    Revoked,
+    Burned,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -46,6 +63,7 @@ pub struct UserReputationMetrics {
     pub total_cycles: u32,
     pub perfect_cycles: u32,
     pub total_volume_saved: i128,
+    pub defaults_count: u32,
     pub last_updated: u64,
 }
 
@@ -62,93 +80,529 @@ pub struct ReputationMilestone {
 #[contract]
 pub struct SoroSusuSbtMinter;
 
+fn default_metrics(now: u64) -> UserReputationMetrics {
+    UserReputationMetrics {
+        reliability_score: DEFAULT_RELIABILITY_SCORE,
+        social_capital_score: DEFAULT_SOCIAL_CAPITAL_SCORE,
+        total_cycles: 0,
+        perfect_cycles: 0,
+        total_volume_saved: 0,
+        defaults_count: 0,
+        last_updated: now,
+    }
+}
+
+fn tier_for_score(score: u32) -> ReputationTier {
+    if score >= 9_500 {
+        ReputationTier::Diamond
+    } else if score >= 8_500 {
+        ReputationTier::Platinum
+    } else if score >= 7_500 {
+        ReputationTier::Gold
+    } else if score >= 6_500 {
+        ReputationTier::Silver
+    } else {
+        ReputationTier::Bronze
+    }
+}
+
+fn status_for_tier(tier: &ReputationTier) -> SbtStatus {
+    match tier {
+        ReputationTier::Bronze => SbtStatus::Discovery,
+        ReputationTier::Silver => SbtStatus::Pathfinder,
+        ReputationTier::Gold => SbtStatus::Guardian,
+        ReputationTier::Platinum => SbtStatus::Luminary,
+        ReputationTier::Diamond => SbtStatus::SusuLegend,
+    }
+}
+
+fn metadata_for_status(env: &Env, status: &SbtStatus) -> String {
+    match status {
+        SbtStatus::Discovery => String::from_str(env, "ipfs://sorosusu/reputation/bronze"),
+        SbtStatus::Pathfinder => String::from_str(env, "ipfs://sorosusu/reputation/silver"),
+        SbtStatus::Guardian => String::from_str(env, "ipfs://sorosusu/reputation/gold"),
+        SbtStatus::Luminary => String::from_str(env, "ipfs://sorosusu/reputation/platinum"),
+        SbtStatus::SusuLegend => String::from_str(env, "ipfs://sorosusu/reputation/diamond"),
+        SbtStatus::Delinquent => String::from_str(env, "ipfs://sorosusu/reputation/delinquent"),
+        SbtStatus::Revoked => String::from_str(env, "ipfs://sorosusu/reputation/revoked"),
+        SbtStatus::Burned => String::from_str(env, "ipfs://sorosusu/reputation/burned"),
+    }
+}
+
+fn is_locked_status(status: &SbtStatus) -> bool {
+    matches!(
+        status,
+        SbtStatus::Delinquent | SbtStatus::Revoked | SbtStatus::Burned
+    )
+}
+
+fn require_admin(env: &Env) -> Address {
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&SbtDataKey::Admin)
+        .unwrap_or_else(|| panic!("SBT minter not initialized"));
+    admin.require_auth();
+    admin
+}
+
+fn emit_badge_update(env: &Env, credential: &SoroSusuCredential) {
+    env.events().publish(
+        (
+            Symbol::new(env, "ReputationBadgeUpdated"),
+            credential.token_id,
+        ),
+        (
+            credential.user.clone(),
+            credential.status.clone(),
+            credential.metadata_uri.clone(),
+        ),
+    );
+}
+
+fn compute_reliability_score(total_cycles: u32, perfect_cycles: u32, defaults_count: u32) -> u32 {
+    if total_cycles == 0 {
+        return DEFAULT_RELIABILITY_SCORE;
+    }
+
+    let on_time_score = (perfect_cycles.min(total_cycles) * 10_000) / total_cycles;
+    let default_penalty = defaults_count.saturating_mul(1_500);
+    on_time_score.saturating_sub(default_penalty)
+}
+
+fn next_token_id(env: &Env) -> u128 {
+    let mut count: u128 = env
+        .storage()
+        .instance()
+        .get(&SbtDataKey::CredentialCount)
+        .unwrap_or(0);
+    count += 1;
+    env.storage()
+        .instance()
+        .set(&SbtDataKey::CredentialCount, &count);
+    count
+}
+
+fn refresh_credential_from_metrics(
+    env: &Env,
+    mut credential: SoroSusuCredential,
+) -> SoroSusuCredential {
+    if is_locked_status(&credential.status) {
+        credential.metadata_uri = metadata_for_status(env, &credential.status);
+        return credential;
+    }
+
+    let metrics: UserReputationMetrics = env
+        .storage()
+        .instance()
+        .get(&SbtDataKey::UserReputation(credential.user.clone()))
+        .unwrap_or_else(|| default_metrics(env.ledger().timestamp()));
+
+    credential.reputation_score = metrics.reliability_score;
+    credential.status = status_for_tier(&tier_for_score(metrics.reliability_score));
+    credential.metadata_uri = metadata_for_status(env, &credential.status);
+    credential
+}
+
+fn store_credential(env: &Env, credential: &SoroSusuCredential) {
+    env.storage()
+        .instance()
+        .set(&SbtDataKey::Credential(credential.token_id), credential);
+    env.storage().instance().set(
+        &SbtDataKey::UserCredential(credential.user.clone()),
+        &credential.token_id,
+    );
+}
+
 #[contractimpl]
 impl SoroSusuSbtMinter {
     // Initialize SBT Minter with admin
     pub fn init_sbt_minter(env: Env, admin: Address) {
         admin.require_auth();
-        env.storage().instance().set(&DataKey::K(symbol_short!("SbtAdm")), &admin);
-        env.storage().instance().set(&DataKey::K(symbol_short!("MileCnt")), &0u64);
+        env.storage().instance().set(&SbtDataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&SbtDataKey::MilestoneCount, &0u64);
+        env.storage()
+            .instance()
+            .set(&SbtDataKey::CredentialCount, &0u128);
     }
 
     // Set new admin
     pub fn set_sbt_minter_admin(env: Env, admin: Address, new_admin: Address) {
-        let current_admin: Address = env.storage().instance().get(&DataKey::K(symbol_short!("SbtAdm"))).unwrap();
+        let current_admin: Address = env.storage().instance().get(&SbtDataKey::Admin).unwrap();
         admin.require_auth();
-        if admin != current_admin { panic!(); }
-        env.storage().instance().set(&DataKey::K(symbol_short!("SbtAdm")), &new_admin);
+        if admin != current_admin {
+            panic!();
+        }
+        env.storage().instance().set(&SbtDataKey::Admin, &new_admin);
     }
 
-    // Issue SBT credential
-    pub fn issue_credential(env: Env, user: Address, milestone_id: u64, metadata_uri: String) -> u128 {
-        let milestone: ReputationMilestone = env.storage().instance().get(&DataKey::K1(symbol_short!("Mile"), milestone_id)).unwrap();
-        if milestone.user != user { panic!(); }
-        if milestone.is_completed { panic!(); }
-        
-        let metrics: UserReputationMetrics = env.storage().instance().get(&DataKey::K1A(symbol_short!("URep"), user.clone())).unwrap_or(UserReputationMetrics {
-            reliability_score: 5000, social_capital_score: 5000, total_cycles: 0, perfect_cycles: 0, last_updated: 0, total_volume_saved: 0,
-        });
+    // Issue SBT credential for an admin-created 12-month milestone.
+    pub fn issue_credential(
+        env: Env,
+        user: Address,
+        milestone_id: u64,
+        _metadata_uri: String,
+    ) -> u128 {
+        let mut milestone: ReputationMilestone = env
+            .storage()
+            .instance()
+            .get(&SbtDataKey::Milestone(milestone_id))
+            .unwrap();
+        if milestone.user != user {
+            panic!();
+        }
+        if milestone.is_completed {
+            panic!();
+        }
+        if milestone.required_cycles < MIN_REPUTATION_BADGE_CYCLES {
+            panic!("minimum 12 cycles required");
+        }
 
-        let reputation_score = (metrics.reliability_score + metrics.social_capital_score) / 2;
-        let token_id = env.ledger().timestamp() as u128 + metrics.total_cycles as u128; // Simple unique ID for mock
+        let metrics: UserReputationMetrics = env
+            .storage()
+            .instance()
+            .get(&SbtDataKey::UserReputation(user.clone()))
+            .unwrap_or_else(|| default_metrics(env.ledger().timestamp()));
+        if metrics.total_cycles < milestone.required_cycles {
+            panic!("milestone not complete");
+        }
+        if metrics.total_volume_saved <= 0 {
+            panic!("zero-value cycles cannot mint reputation badges");
+        }
 
+        let reputation_score = metrics.reliability_score;
+        let token_id = if let Some(existing) = env
+            .storage()
+            .instance()
+            .get::<SbtDataKey, u128>(&SbtDataKey::UserCredential(user.clone()))
+        {
+            existing
+        } else {
+            next_token_id(&env)
+        };
+        let status = status_for_tier(&milestone.tier);
         let credential = SoroSusuCredential {
             token_id,
             user: user.clone(),
-            status: match milestone.tier {
-                ReputationTier::Bronze => SbtStatus::Discovery,
-                ReputationTier::Silver => SbtStatus::Pathfinder,
-                ReputationTier::Gold => SbtStatus::Guardian,
-                ReputationTier::Platinum => SbtStatus::Luminary,
-                ReputationTier::Diamond => SbtStatus::SusuLegend,
-            },
+            status: status.clone(),
             reputation_score,
-            metadata_uri,
+            metadata_uri: metadata_for_status(&env, &status),
             issue_date: env.ledger().timestamp(),
         };
 
-        env.storage().instance().set(&DataKey::K1U(symbol_short!("Cred"), token_id), &credential);
-        env.storage().instance().set(&DataKey::K1A(symbol_short!("UCred"), user), &token_id);
-        
+        store_credential(&env, &credential);
+        milestone.is_completed = true;
+        env.storage()
+            .instance()
+            .set(&SbtDataKey::Milestone(milestone_id), &milestone);
+        emit_badge_update(&env, &credential);
+
         token_id
     }
 
     pub fn update_credential_status(env: Env, token_id: u128, new_status: SbtStatus) {
-        let admin: Address = env.storage().instance().get(&DataKey::K(symbol_short!("SbtAdm"))).unwrap();
-        admin.require_auth();
-        let mut credential: SoroSusuCredential = env.storage().instance().get(&DataKey::K1U(symbol_short!("Cred"), token_id)).unwrap();
+        require_admin(&env);
+        let mut credential: SoroSusuCredential = env
+            .storage()
+            .instance()
+            .get(&SbtDataKey::Credential(token_id))
+            .unwrap();
         credential.status = new_status;
-        env.storage().instance().set(&DataKey::K1U(symbol_short!("Cred"), token_id), &credential);
+        credential.metadata_uri = metadata_for_status(&env, &credential.status);
+        store_credential(&env, &credential);
+        emit_badge_update(&env, &credential);
+    }
+
+    pub fn revoke_credential(env: Env, token_id: u128, reason: String) {
+        require_admin(&env);
+        let mut credential: SoroSusuCredential = env
+            .storage()
+            .instance()
+            .get(&SbtDataKey::Credential(token_id))
+            .unwrap();
+        credential.status = SbtStatus::Revoked;
+        credential.metadata_uri = metadata_for_status(&env, &credential.status);
+        store_credential(&env, &credential);
+        env.events().publish(
+            (symbol_short!("SBTREV"), token_id),
+            (credential.user.clone(), reason),
+        );
+        emit_badge_update(&env, &credential);
+    }
+
+    pub fn burn_credential(env: Env, token_id: u128) {
+        require_admin(&env);
+        let mut credential: SoroSusuCredential = env
+            .storage()
+            .instance()
+            .get(&SbtDataKey::Credential(token_id))
+            .unwrap();
+        credential.status = SbtStatus::Burned;
+        credential.metadata_uri = metadata_for_status(&env, &credential.status);
+        store_credential(&env, &credential);
+        emit_badge_update(&env, &credential);
+    }
+
+    pub fn mark_defaulted(env: Env, user: Address) {
+        require_admin(&env);
+        let token_id: u128 = env
+            .storage()
+            .instance()
+            .get(&SbtDataKey::UserCredential(user.clone()))
+            .unwrap_or_else(|| panic!("credential not found"));
+
+        let mut metrics: UserReputationMetrics = env
+            .storage()
+            .instance()
+            .get(&SbtDataKey::UserReputation(user.clone()))
+            .unwrap_or_else(|| default_metrics(env.ledger().timestamp()));
+        metrics.defaults_count += 1;
+        metrics.reliability_score = compute_reliability_score(
+            metrics.total_cycles,
+            metrics.perfect_cycles,
+            metrics.defaults_count,
+        );
+        metrics.last_updated = env.ledger().timestamp();
+        env.storage()
+            .instance()
+            .set(&SbtDataKey::UserReputation(user), &metrics);
+
+        let mut credential: SoroSusuCredential = env
+            .storage()
+            .instance()
+            .get(&SbtDataKey::Credential(token_id))
+            .unwrap();
+        credential.status = SbtStatus::Delinquent;
+        credential.reputation_score = metrics.reliability_score;
+        credential.metadata_uri = metadata_for_status(&env, &credential.status);
+        store_credential(&env, &credential);
+        emit_badge_update(&env, &credential);
+    }
+
+    pub fn record_cycle_completion(
+        env: Env,
+        admin: Address,
+        user: Address,
+        circle_id: u64,
+        cycle_value: i128,
+        cycles_completed: u32,
+        on_time_cycles: u32,
+    ) -> u128 {
+        let stored_admin: Address = env.storage().instance().get(&SbtDataKey::Admin).unwrap();
+        admin.require_auth();
+        if admin != stored_admin {
+            panic!("unauthorized");
+        }
+        if cycle_value <= 0 {
+            panic!("zero-value cycles cannot mint reputation badges");
+        }
+        if cycles_completed < MIN_REPUTATION_BADGE_CYCLES {
+            panic!("minimum 12 cycles required");
+        }
+        if on_time_cycles > cycles_completed {
+            panic!("invalid on-time cycle count");
+        }
+
+        let award_key = SbtDataKey::CycleAward(user.clone(), circle_id, cycles_completed);
+        if env.storage().instance().has(&award_key) {
+            panic!("cycle already recorded");
+        }
+        env.storage().instance().set(&award_key, &true);
+
+        let mut metrics: UserReputationMetrics = env
+            .storage()
+            .instance()
+            .get(&SbtDataKey::UserReputation(user.clone()))
+            .unwrap_or_else(|| default_metrics(env.ledger().timestamp()));
+        metrics.total_cycles = metrics.total_cycles.saturating_add(cycles_completed);
+        metrics.perfect_cycles = metrics.perfect_cycles.saturating_add(on_time_cycles);
+        metrics.total_volume_saved = metrics.total_volume_saved.saturating_add(cycle_value);
+        metrics.reliability_score = compute_reliability_score(
+            metrics.total_cycles,
+            metrics.perfect_cycles,
+            metrics.defaults_count,
+        );
+        metrics.last_updated = env.ledger().timestamp();
+        env.storage()
+            .instance()
+            .set(&SbtDataKey::UserReputation(user.clone()), &metrics);
+
+        let token_id = env
+            .storage()
+            .instance()
+            .get::<SbtDataKey, u128>(&SbtDataKey::UserCredential(user.clone()))
+            .unwrap_or_else(|| next_token_id(&env));
+
+        let status = status_for_tier(&tier_for_score(metrics.reliability_score));
+        let credential = SoroSusuCredential {
+            token_id,
+            user: user.clone(),
+            status: status.clone(),
+            reputation_score: metrics.reliability_score,
+            metadata_uri: metadata_for_status(&env, &status),
+            issue_date: env.ledger().timestamp(),
+        };
+
+        store_credential(&env, &credential);
+        emit_badge_update(&env, &credential);
+        token_id
+    }
+
+    pub fn refresh_metadata(env: Env, token_id: u128) -> String {
+        let credential: SoroSusuCredential = env
+            .storage()
+            .instance()
+            .get(&SbtDataKey::Credential(token_id))
+            .unwrap();
+        let refreshed = refresh_credential_from_metrics(&env, credential);
+        store_credential(&env, &refreshed);
+        emit_badge_update(&env, &refreshed);
+        refreshed.metadata_uri
+    }
+
+    pub fn metadata_uri(env: Env, token_id: u128) -> String {
+        let credential: SoroSusuCredential = env
+            .storage()
+            .instance()
+            .get(&SbtDataKey::Credential(token_id))
+            .unwrap();
+        refresh_credential_from_metrics(&env, credential).metadata_uri
+    }
+
+    pub fn get_current_tier(env: Env, token_id: u128) -> ReputationTier {
+        let credential: SoroSusuCredential = env
+            .storage()
+            .instance()
+            .get(&SbtDataKey::Credential(token_id))
+            .unwrap();
+        if credential.status == SbtStatus::Delinquent
+            || credential.status == SbtStatus::Revoked
+            || credential.status == SbtStatus::Burned
+        {
+            return ReputationTier::Bronze;
+        }
+        tier_for_score(refresh_credential_from_metrics(&env, credential).reputation_score)
     }
 
     pub fn get_credential(env: Env, token_id: u128) -> SoroSusuCredential {
-        env.storage().instance().get(&DataKey::K1U(symbol_short!("Cred"), token_id)).unwrap()
+        let credential: SoroSusuCredential = env
+            .storage()
+            .instance()
+            .get(&SbtDataKey::Credential(token_id))
+            .unwrap();
+        refresh_credential_from_metrics(&env, credential)
     }
 
     pub fn get_user_credential(env: Env, user: Address) -> Option<SoroSusuCredential> {
-        let token_id: Option<u128> = env.storage().instance().get(&DataKey::K1A(symbol_short!("UCred"), user));
-        token_id.map(|id| env.storage().instance().get(&DataKey::K1U(symbol_short!("Cred"), id)).unwrap())
+        let token_id: Option<u128> = env
+            .storage()
+            .instance()
+            .get(&SbtDataKey::UserCredential(user));
+        token_id.map(|id| Self::get_credential(env.clone(), id))
     }
 
-    pub fn create_reputation_milestone(env: Env, user: Address, cycles: u32, desc: String, tier: ReputationTier) -> u64 {
-        let admin: Address = env.storage().instance().get(&DataKey::K(symbol_short!("SbtAdm"))).unwrap();
-        admin.require_auth();
-        let mut count: u64 = env.storage().instance().get(&DataKey::K(symbol_short!("MileCnt"))).unwrap_or(0);
+    pub fn create_reputation_milestone(
+        env: Env,
+        user: Address,
+        cycles: u32,
+        desc: String,
+        tier: ReputationTier,
+    ) -> u64 {
+        require_admin(&env);
+        if cycles < MIN_REPUTATION_BADGE_CYCLES {
+            panic!("minimum 12 cycles required");
+        }
+        let mut count: u64 = env
+            .storage()
+            .instance()
+            .get(&SbtDataKey::MilestoneCount)
+            .unwrap_or(0);
         count += 1;
-        let milestone = ReputationMilestone { user, required_cycles: cycles, description: desc, tier, is_completed: false };
-        env.storage().instance().set(&DataKey::K1(symbol_short!("Mile"), count), &milestone);
-        env.storage().instance().set(&DataKey::K(symbol_short!("MileCnt")), &count);
+        let milestone = ReputationMilestone {
+            user,
+            required_cycles: cycles,
+            description: desc,
+            tier,
+            is_completed: false,
+        };
+        env.storage()
+            .instance()
+            .set(&SbtDataKey::Milestone(count), &milestone);
+        env.storage()
+            .instance()
+            .set(&SbtDataKey::MilestoneCount, &count);
         count
     }
 
     pub fn get_reputation_milestone(env: Env, milestone_id: u64) -> ReputationMilestone {
-        env.storage().instance().get(&DataKey::K1(symbol_short!("Mile"), milestone_id)).unwrap()
+        env.storage()
+            .instance()
+            .get(&SbtDataKey::Milestone(milestone_id))
+            .unwrap()
+    }
+
+    pub fn update_user_reputation_metrics(
+        env: Env,
+        admin: Address,
+        user: Address,
+        reliability_score: u32,
+        social_capital_score: u32,
+        total_cycles: u32,
+        perfect_cycles: u32,
+        total_volume_saved: i128,
+    ) {
+        let stored_admin: Address = env.storage().instance().get(&SbtDataKey::Admin).unwrap();
+        admin.require_auth();
+        if admin != stored_admin {
+            panic!("unauthorized");
+        }
+        if reliability_score > 10_000 || social_capital_score > 10_000 {
+            panic!("score out of range");
+        }
+        let metrics = UserReputationMetrics {
+            reliability_score,
+            social_capital_score,
+            total_cycles,
+            perfect_cycles,
+            total_volume_saved,
+            defaults_count: 0,
+            last_updated: env.ledger().timestamp(),
+        };
+        env.storage()
+            .instance()
+            .set(&SbtDataKey::UserReputation(user), &metrics);
     }
 
     pub fn get_user_reputation_score(env: Env, user: Address) -> (u32, u32, u32) {
-        let metrics: UserReputationMetrics = env.storage().instance().get(&DataKey::K1A(symbol_short!("URep"), user)).unwrap_or(UserReputationMetrics {
-            reliability_score: 5000, social_capital_score: 5000, total_cycles: 0, perfect_cycles: 0, last_updated: 0, total_volume_saved: 0,
-        });
-        (metrics.reliability_score, metrics.social_capital_score, (metrics.reliability_score + metrics.social_capital_score) / 2)
+        let metrics: UserReputationMetrics = env
+            .storage()
+            .instance()
+            .get(&SbtDataKey::UserReputation(user))
+            .unwrap_or_else(|| default_metrics(env.ledger().timestamp()));
+        (
+            metrics.reliability_score,
+            metrics.social_capital_score,
+            (metrics.reliability_score + metrics.social_capital_score) / 2,
+        )
+    }
+
+    pub fn transfer(_env: Env, _from: Address, _to: Address, _token_id: u128) {
+        panic!("SBT is non-transferable");
+    }
+
+    pub fn transfer_from(
+        _env: Env,
+        _spender: Address,
+        _from: Address,
+        _to: Address,
+        _token_id: u128,
+    ) {
+        panic!("SBT is non-transferable");
+    }
+
+    pub fn approve(_env: Env, _owner: Address, _spender: Address, _token_id: u128) {
+        panic!("SBT approvals are disabled");
     }
 }

--- a/tests/reputation_adapter_test.rs
+++ b/tests/reputation_adapter_test.rs
@@ -1,0 +1,106 @@
+#![cfg(test)]
+
+use soroban_sdk::testutils::{Address as _, Events as _};
+use soroban_sdk::{Address, Env};
+use sorosusu_contracts::reliability_oracle::{
+    archive_reputation, is_reputable_user, update_reputation, SoroSusuReputationAdapter,
+    SoroSusuReputationAdapterClient, REPUTABLE_USER_CPU_BUDGET,
+};
+
+fn setup_adapter(env: &Env) -> (Address, SoroSusuReputationAdapterClient<'_>) {
+    let adapter_id = env.register_contract(None, SoroSusuReputationAdapter);
+    let client = SoroSusuReputationAdapterClient::new(env, &adapter_id);
+    (adapter_id, client)
+}
+
+fn store_reputation(
+    env: &Env,
+    adapter_id: &Address,
+    user: &Address,
+    ri_score: u32,
+    defaults_count: u32,
+) {
+    env.as_contract(adapter_id, || {
+        update_reputation(env, user.clone(), ri_score, 24, 24, defaults_count, 0, 0, 2);
+    });
+}
+
+#[test]
+fn reputable_user_requires_ri_above_900_and_zero_defaults() {
+    let env = Env::default();
+    let (adapter_id, client) = setup_adapter(&env);
+    let user = Address::generate(&env);
+
+    store_reputation(&env, &adapter_id, &user, 901, 0);
+
+    assert!(client.is_reputable_user(&user));
+}
+
+#[test]
+fn threshold_is_strict_and_defaults_disqualify_user() {
+    let env = Env::default();
+    let (adapter_id, client) = setup_adapter(&env);
+    let threshold_user = Address::generate(&env);
+    let defaulted_user = Address::generate(&env);
+
+    store_reputation(&env, &adapter_id, &threshold_user, 900, 0);
+    store_reputation(&env, &adapter_id, &defaulted_user, 950, 1);
+
+    assert!(!client.is_reputable_user(&threshold_user));
+    assert!(!client.is_reputable_user(&defaulted_user));
+}
+
+#[test]
+fn missing_or_archived_reputation_defaults_to_false() {
+    let env = Env::default();
+    let (adapter_id, client) = setup_adapter(&env);
+    let missing_user = Address::generate(&env);
+    let archived_user = Address::generate(&env);
+
+    assert!(!client.is_reputable_user(&missing_user));
+
+    store_reputation(&env, &adapter_id, &archived_user, 980, 0);
+    env.as_contract(&adapter_id, || {
+        archive_reputation(&env, archived_user.clone())
+    });
+
+    assert!(!client.is_reputable_user(&archived_user));
+}
+
+#[test]
+fn adapter_emits_zero_events() {
+    let env = Env::default();
+    let (adapter_id, client) = setup_adapter(&env);
+    let user = Address::generate(&env);
+    store_reputation(&env, &adapter_id, &user, 980, 0);
+
+    let event_count_before = env.events().all().len();
+
+    assert!(client.is_reputable_user(&user));
+    assert_eq!(env.events().all().len(), event_count_before);
+}
+
+#[test]
+fn adapter_executes_under_5000_cpu_instructions() {
+    let env = Env::default();
+    let (adapter_id, _) = setup_adapter(&env);
+    let user = Address::generate(&env);
+    store_reputation(&env, &adapter_id, &user, 980, 0);
+
+    let (result, consumed) = env.as_contract(&adapter_id, || {
+        assert!(is_reputable_user(&env, user.clone()));
+
+        let mut budget = env.budget();
+        budget.reset_default();
+        let before = budget.cpu_instruction_cost();
+        let result = is_reputable_user(&env, user);
+        (result, budget.cpu_instruction_cost() - before)
+    });
+
+    assert!(result);
+    assert!(
+        consumed < REPUTABLE_USER_CPU_BUDGET,
+        "is_reputable_user used {} CPU instructions",
+        consumed
+    );
+}

--- a/tests/sbt_minter_test.rs
+++ b/tests/sbt_minter_test.rs
@@ -1,31 +1,181 @@
 #![cfg(test)]
-use soroban_sdk::testutils::Address as _;
+use soroban_sdk::testutils::{Address as _, Events as _};
 use soroban_sdk::{Address, Env, String};
 use sorosusu_contracts::sbt_minter::{
-    SoroSusuSbtMinter, SoroSusuSbtMinterClient, SbtStatus, ReputationTier
+    ReputationTier, SbtStatus, SoroSusuSbtMinter, SoroSusuSbtMinterClient,
 };
 
 #[test]
 fn test_sbt_minter_flow() {
     let env = Env::default();
     env.mock_all_auths();
-    
+
     let admin = Address::generate(&env);
     let user = Address::generate(&env);
-    
+
     let minter_id = env.register_contract(None, SoroSusuSbtMinter);
     let client = SoroSusuSbtMinterClient::new(&env, &minter_id);
-    
-    client.init_sbt_minter(&admin);
-    
-    let desc = String::from_str(&env, "Complete 5 cycles");
-    let mid = client.create_reputation_milestone(&user, &5u32, &desc, &ReputationTier::Silver);
-    
-    let m = client.get_reputation_milestone(&mid);
-    assert_eq!(m.required_cycles, 5);
 
-    let tid = client.issue_credential(&user, &mid, &String::from_str(&env, "uri"));
+    client.init_sbt_minter(&admin);
+
+    client.update_user_reputation_metrics(
+        &admin,
+        &user,
+        &8_500u32,
+        &7_000u32,
+        &12u32,
+        &12u32,
+        &12_000i128,
+    );
+
+    let desc = String::from_str(&env, "Complete a 12-month cycle");
+    let mid = client.create_reputation_milestone(&user, &12u32, &desc, &ReputationTier::Platinum);
+
+    let m = client.get_reputation_milestone(&mid);
+    assert_eq!(m.required_cycles, 12);
+
+    let tid = client.issue_credential(&user, &mid, &String::from_str(&env, ""));
     let cred = client.get_credential(&tid);
     assert_eq!(cred.user, user);
-    assert_eq!(cred.status, SbtStatus::Pathfinder);
+    assert_eq!(cred.status, SbtStatus::Luminary);
+    assert_eq!(
+        cred.metadata_uri,
+        String::from_str(&env, "ipfs://sorosusu/reputation/platinum")
+    );
+}
+
+#[test]
+fn test_12_month_cycle_mints_dynamic_reputation_badge() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let minter_id = env.register_contract(None, SoroSusuSbtMinter);
+    let client = SoroSusuSbtMinterClient::new(&env, &minter_id);
+    client.init_sbt_minter(&admin);
+
+    let token_id =
+        client.record_cycle_completion(&admin, &user, &1u64, &12_000i128, &12u32, &12u32);
+
+    let cred = client.get_user_credential(&user).unwrap();
+    assert_eq!(cred.token_id, token_id);
+    assert_eq!(cred.status, SbtStatus::SusuLegend);
+    assert_eq!(client.get_current_tier(&token_id), ReputationTier::Diamond);
+    assert_eq!(
+        client.metadata_uri(&token_id),
+        String::from_str(&env, "ipfs://sorosusu/reputation/diamond")
+    );
+    assert!(!env.events().all().is_empty());
+}
+
+#[test]
+fn test_reputation_badge_tier_updates_as_on_time_cycles_improve() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let minter_id = env.register_contract(None, SoroSusuSbtMinter);
+    let client = SoroSusuSbtMinterClient::new(&env, &minter_id);
+    client.init_sbt_minter(&admin);
+
+    let token_id = client.record_cycle_completion(&admin, &user, &1u64, &12_000i128, &12u32, &6u32);
+    assert_eq!(client.get_current_tier(&token_id), ReputationTier::Bronze);
+
+    let same_token_id =
+        client.record_cycle_completion(&admin, &user, &2u64, &12_000i128, &12u32, &12u32);
+    assert_eq!(same_token_id, token_id);
+    assert_eq!(client.get_current_tier(&token_id), ReputationTier::Gold);
+    assert_eq!(
+        client.metadata_uri(&token_id),
+        String::from_str(&env, "ipfs://sorosusu/reputation/gold")
+    );
+}
+
+#[test]
+fn test_zero_value_cycle_cannot_mint_reputation_badge() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let minter_id = env.register_contract(None, SoroSusuSbtMinter);
+    let client = SoroSusuSbtMinterClient::new(&env, &minter_id);
+    client.init_sbt_minter(&admin);
+
+    let result = client.try_record_cycle_completion(&admin, &user, &1u64, &0i128, &12u32, &12u32);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_soulbound_transfer_always_reverts() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let other = Address::generate(&env);
+
+    let minter_id = env.register_contract(None, SoroSusuSbtMinter);
+    let client = SoroSusuSbtMinterClient::new(&env, &minter_id);
+    client.init_sbt_minter(&admin);
+    let token_id =
+        client.record_cycle_completion(&admin, &user, &1u64, &12_000i128, &12u32, &12u32);
+
+    let result = client.try_transfer(&user, &other, &token_id);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_default_switches_metadata_to_delinquent() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let minter_id = env.register_contract(None, SoroSusuSbtMinter);
+    let client = SoroSusuSbtMinterClient::new(&env, &minter_id);
+    client.init_sbt_minter(&admin);
+    let token_id =
+        client.record_cycle_completion(&admin, &user, &1u64, &12_000i128, &12u32, &12u32);
+
+    client.mark_defaulted(&user);
+
+    let cred = client.get_credential(&token_id);
+    assert_eq!(cred.status, SbtStatus::Delinquent);
+    assert_eq!(
+        cred.metadata_uri,
+        String::from_str(&env, "ipfs://sorosusu/reputation/delinquent")
+    );
+}
+
+#[test]
+fn test_admin_can_revoke_and_burn_badge_for_fraud() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    let minter_id = env.register_contract(None, SoroSusuSbtMinter);
+    let client = SoroSusuSbtMinterClient::new(&env, &minter_id);
+    client.init_sbt_minter(&admin);
+    let token_id =
+        client.record_cycle_completion(&admin, &user, &1u64, &12_000i128, &12u32, &12u32);
+
+    client.revoke_credential(&token_id, &String::from_str(&env, "fraud"));
+    assert_eq!(client.get_credential(&token_id).status, SbtStatus::Revoked);
+
+    client.burn_credential(&token_id);
+    let cred = client.get_credential(&token_id);
+    assert_eq!(cred.status, SbtStatus::Burned);
+    assert_eq!(
+        cred.metadata_uri,
+        String::from_str(&env, "ipfs://sorosusu/reputation/burned")
+    );
 }


### PR DESCRIPTION
Closes #382
Closes #387
Closes #407
This PR completes three SoroSusu protocol improvements focused on contribution efficiency, reputation credentials, and external reputation interoperability.

1. Batch Contribution History Optimization
Optimizes member deposits by allowing multiple contribution rounds to be processed in a single ledger transaction. Instead of performing repeated token transfers and member-history writes per round, the contract now aggregates the total contribution amount, performs one transfer, and updates the member’s contribution history atomically. This reduces storage writes, improves ledger efficiency, and makes multi-round catch-up payments cheaper and safer.

2. Reputation-NFT / Soulbound Badge Metadata Hooks
Adds reputation badge logic for users who successfully complete valid 12-month Susu cycles. The badge acts as a non-transferable Soulbound Token representing the user’s on-chain reliability. Its metadata dynamically reflects the user’s current Reliability Index tier, such as Bronze, Gold, Platinum, or Diamond. The logic prevents fake zero-value cycle spam, blocks all transfer and approval paths, supports delinquent metadata when a user defaults, and allows revocation or burn flows for fraud cases.

3. Reputation-as-a-Service Partner Adapter
Introduces a standardized is_reputable_user(address) read-only adapter for partner Stellar dApps. External protocols can query this hook to determine whether a user qualifies for VIP or under-collateralized features. The adapter returns true only when the user’s Reliability Index is greater than 900 and they have zero defaults. It exposes only a boolean result, emits no events, avoids leaking private group membership data, and defaults to false when reputation data is missing or archived.

Testing
Added coverage for:

Batch contribution updates across multiple rounds.
Reputation badge minting, tier updates, delinquent state, revocation, burn, and transfer prevention.
Zero-value cycle anti-spam protection.
is_reputable_user behavior for qualified users, defaulted users, missing/archived records, zero-event execution, and CPU-budget performance.