### PR TITLE
Refactor: Replace panic! calls with Result types

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,628 @@
+#![cfg_attr(not(test), no_std)]
+use soroban_sdk::{contracttype, Error, Symbol};
+
+/// Comprehensive error system for SoroSusu smart contracts
+/// Each error variant maps to a unique u32 code for frontend parsing
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SoroSusuError {
+    // General errors (1000-1999)
+    Unauthorized = 1000,
+    InvalidInput = 1001,
+    Overflow = 1002,
+    NotFound = 1003,
+    AlreadyExists = 1004,
+    InsufficientBalance = 1005,
+    InvalidState = 1006,
+    ArithmeticError = 1007,
+    DivisionByZero = 1008,
+    InvalidAddress = 1009,
+    TimestampError = 1010,
+    StorageError = 1011,
+    SerializationError = 1012,
+    InvalidSignature = 1013,
+    RateLimitExceeded = 1014,
+    MaintenanceMode = 1015,
+
+    // Circle management errors (2000-2999)
+    CircleNotFound = 2000,
+    CircleAlreadyExists = 2001,
+    CircleIsFull = 2002,
+    CircleNotActive = 2003,
+    CircleAlreadyFinalized = 2004,
+    CircleNotMatured = 2005,
+    InvalidCircleDuration = 2006,
+    MaxGroupSizeExceeded = 2007,
+    CircleCompleted = 2008,
+    CircleNotCompleted = 2009,
+    InvalidContributionAmount = 2010,
+    InvalidInsuranceFee = 2011,
+    InvalidMaxMembers = 2012,
+    CircleDrained = 2013,
+    CircleNotDrained = 2014,
+
+    // Member management errors (3000-3999)
+    MemberNotFound = 3000,
+    MemberAlreadyExists = 3001,
+    MemberNotActive = 3002,
+    MemberIndexOutOfBounds = 3003,
+    MemberAlreadyPaid = 3004,
+    MemberNotPaid = 3005,
+    InvalidMemberStatus = 3006,
+    MemberIneligible = 3007,
+    MemberDefaulted = 3008,
+    MemberNotDefaulted = 3009,
+    TooManyMembers = 3010,
+    InsufficientMembers = 3011,
+    MemberNotRecipient = 3012,
+    MemberAlreadyRecipient = 3013,
+
+    // Contribution and payment errors (4000-4999)
+    InvalidContribution = 4000,
+    ContributionOverflow = 4001,
+    InsufficientContribution = 4002,
+    ContributionAlreadyMade = 4003,
+    ContributionNotMade = 4004,
+    InvalidRounds = 4005,
+    ZeroRounds = 4006,
+    ContributionPeriodClosed = 4007,
+    ContributionPeriodOpen = 4008,
+    PaymentFailed = 4009,
+    InvalidPaymentAmount = 4010,
+    PaymentAlreadyProcessed = 4011,
+    PaymentNotDue = 4012,
+    LateFeeApplicable = 4013,
+    LateFeeNotApplicable = 4014,
+
+    // Payout and distribution errors (5000-5999)
+    NoRecipientSet = 5000,
+    PayoutAlreadyDistributed = 5001,
+    InsufficientPotBalance = 5002,
+    InvalidPayoutAmount = 5003,
+    PayoutFailed = 5004,
+    DistributionFailed = 5005,
+    InvalidDistributionRatio = 5006,
+    YieldNotAvailable = 5007,
+    YieldAlreadyClaimed = 5008,
+    InvalidYieldAmount = 5009,
+    HarvestFailed = 5010,
+    BatchHarvestInProgress = 5011,
+
+    // Recovery and dispute errors (6000-6999)
+    RecoveryNotProposed = 6000,
+    RecoveryAlreadyProposed = 6001,
+    RecoveryNotConsensus = 6002,
+    RecoveryFailed = 6003,
+    InvalidRecoveryAddress = 6004,
+    RecoveryWindowExpired = 6005,
+    DisputeNotFound = 6006,
+    DisputeAlreadyExists = 6007,
+    DisputeNotActive = 6008,
+    DisputeResolved = 6009,
+    InvalidDisputeAmount = 6010,
+    JurorNotSelected = 6011,
+    VotingNotActive = 6012,
+    VotingAlreadyActive = 6013,
+    VotingCompleted = 6014,
+    InvalidVote = 6015,
+
+    // Lending market errors (7000-7999)
+    LendingMarketNotInitialized = 7000,
+    LendingMarketDisabled = 7001,
+    LendingMarketEmergencyMode = 7002,
+    PoolNotFound = 7003,
+    PoolNotActive = 7004,
+    PoolAlreadyExists = 7005,
+    InsufficientPoolLiquidity = 7006,
+    InvalidLiquidityAmount = 7007,
+    PositionNotFound = 7008,
+    PositionNotActive = 7009,
+    LoanAlreadyRepaid = 7010,
+    InvalidLoanAmount = 7011,
+    InvalidLtvRatio = 7012,
+    LtvRatioExceeded = 7013,
+    MinLendingAmount = 7014,
+    ScheduleNotFound = 7015,
+    EmergencyLoanNotFound = 7016,
+    EmergencyLoanNotActive = 7017,
+    VotingPeriodEnded = 7018,
+    QuorumNotMet = 7019,
+
+    // Yield and strategy errors (8000-8999)
+    YieldStrategyNotFound = 8000,
+    YieldStrategyNotActive = 8001,
+    InvalidYieldStrategy = 8002,
+    YieldOracleError = 8003,
+    CircuitBreakerTriggered = 8004,
+    YieldAllocationFailed = 8005,
+    InvalidYieldAllocation = 8006,
+    BridgeAdapterError = 8007,
+    SlippageExceeded = 8008,
+    PriceFeedError = 8009,
+    InvalidPriceData = 8010,
+    YieldCalculationError = 8011,
+
+    // Security and compliance errors (9000-9999)
+    ReentrancyDetected = 9000,
+    Paused = 9001,
+    NotPaused = 9002,
+    EmergencyMode = 9003,
+    Blacklisted = 9004,
+    Sanctioned = 9005,
+    ComplianceFailed = 9006,
+    AmlViolation = 9007,
+    KycRequired = 9008,
+    TaxWithholdingFailed = 9009,
+    InvalidTaxConfiguration = 9010,
+    TaxExemptionInvalid = 9011,
+    AuditEntryMissing = 9012,
+    TrustlineMissing = 9013,
+    AnchorIntegrationError = 9014,
+
+    // Technical and system errors (10000-10999)
+    ContractNotInitialized = 10000,
+    AdminNotSet = 10001,
+    InvalidAdmin = 10002,
+    ConfigurationError = 10003,
+    UpgradeFailed = 10004,
+    MigrationFailed = 10005,
+    BackupFailed = 10006,
+    RestoreFailed = 10007,
+    NetworkError = 10008,
+    GasLimitExceeded = 10009,
+    ExecutionTimeout = 10010,
+    InternalError = 10011,
+    DeprecatedFunction = 10012,
+    FeatureNotEnabled = 10013,
+    InvalidChain = 10014,
+    VersionMismatch = 10015,
+}
+
+impl SoroSusuError {
+    /// Convert error to human-readable message (safe for frontend display)
+    pub fn to_human_readable(&self) -> &'static str {
+        match self {
+            // General errors
+            SoroSusuError::Unauthorized => "You are not authorized to perform this action",
+            SoroSusuError::InvalidInput => "Invalid input provided",
+            SoroSusuError::Overflow => "Arithmetic overflow detected",
+            SoroSusuError::NotFound => "Requested resource not found",
+            SoroSusuError::AlreadyExists => "Resource already exists",
+            SoroSusuError::InsufficientBalance => "Insufficient balance for this operation",
+            SoroSusuError::InvalidState => "Invalid state for this operation",
+            SoroSusuError::ArithmeticError => "Arithmetic operation failed",
+            SoroSusuError::DivisionByZero => "Division by zero attempted",
+            SoroSusuError::InvalidAddress => "Invalid address provided",
+            SoroSusuError::TimestampError => "Invalid timestamp provided",
+            SoroSusuError::StorageError => "Storage operation failed",
+            SoroSusuError::SerializationError => "Data serialization failed",
+            SoroSusuError::InvalidSignature => "Invalid signature provided",
+            SoroSusuError::RateLimitExceeded => "Rate limit exceeded",
+            SoroSusuError::MaintenanceMode => "System is under maintenance",
+
+            // Circle management errors
+            SoroSusuError::CircleNotFound => "Circle not found",
+            SoroSusuError::CircleAlreadyExists => "Circle already exists",
+            SoroSusuError::CircleIsFull => "Circle is full",
+            SoroSusuError::CircleNotActive => "Circle is not active",
+            SoroSusuError::CircleAlreadyFinalized => "Circle round already finalized",
+            SoroSusuError::CircleNotMatured => "Circle has not matured yet",
+            SoroSusuError::InvalidCircleDuration => "Invalid circle duration",
+            SoroSusuError::MaxGroupSizeExceeded => "Maximum group size exceeded",
+            SoroSusuError::CircleCompleted => "Circle is already completed",
+            SoroSusuError::CircleNotCompleted => "Circle is not completed",
+            SoroSusuError::InvalidContributionAmount => "Invalid contribution amount",
+            SoroSusuError::InvalidInsuranceFee => "Invalid insurance fee",
+            SoroSusuError::InvalidMaxMembers => "Invalid maximum members",
+            SoroSusuError::CircleDrained => "Circle has been drained",
+            SoroSusuError::CircleNotDrained => "Circle has not been drained",
+
+            // Member management errors
+            SoroSusuError::MemberNotFound => "Member not found",
+            SoroSusuError::MemberAlreadyExists => "Member already exists",
+            SoroSusuError::MemberNotActive => "Member is not active",
+            SoroSusuError::MemberIndexOutOfBounds => "Member index out of bounds",
+            SoroSusuError::MemberAlreadyPaid => "Member has already paid",
+            SoroSusuError::MemberNotPaid => "Member has not paid",
+            SoroSusuError::InvalidMemberStatus => "Invalid member status",
+            SoroSusuError::MemberIneligible => "Member is ineligible",
+            SoroSusuError::MemberDefaulted => "Member has defaulted",
+            SoroSusuError::MemberNotDefaulted => "Member has not defaulted",
+            SoroSusuError::TooManyMembers => "Too many members",
+            SoroSusuError::InsufficientMembers => "Insufficient members",
+            SoroSusuError::MemberNotRecipient => "Member is not the recipient",
+            SoroSusuError::MemberAlreadyRecipient => "Member is already the recipient",
+
+            // Contribution and payment errors
+            SoroSusuError::InvalidContribution => "Invalid contribution",
+            SoroSusuError::ContributionOverflow => "Contribution overflow",
+            SoroSusuError::InsufficientContribution => "Insufficient contribution",
+            SoroSusuError::ContributionAlreadyMade => "Contribution already made",
+            SoroSusuError::ContributionNotMade => "Contribution not made",
+            SoroSusuError::InvalidRounds => "Invalid number of rounds",
+            SoroSusuError::ZeroRounds => "Number of rounds must be greater than zero",
+            SoroSusuError::ContributionPeriodClosed => "Contribution period is closed",
+            SoroSusuError::ContributionPeriodOpen => "Contribution period is open",
+            SoroSusuError::PaymentFailed => "Payment failed",
+            SoroSusuError::InvalidPaymentAmount => "Invalid payment amount",
+            SoroSusuError::PaymentAlreadyProcessed => "Payment already processed",
+            SoroSusuError::PaymentNotDue => "Payment is not due yet",
+            SoroSusuError::LateFeeApplicable => "Late fee is applicable",
+            SoroSusuError::LateFeeNotApplicable => "Late fee is not applicable",
+
+            // Payout and distribution errors
+            SoroSusuError::NoRecipientSet => "No recipient set",
+            SoroSusuError::PayoutAlreadyDistributed => "Payout already distributed",
+            SoroSusuError::InsufficientPotBalance => "Insufficient pot balance",
+            SoroSusuError::InvalidPayoutAmount => "Invalid payout amount",
+            SoroSusuError::PayoutFailed => "Payout failed",
+            SoroSusuError::DistributionFailed => "Distribution failed",
+            SoroSusuError::InvalidDistributionRatio => "Invalid distribution ratio",
+            SoroSusuError::YieldNotAvailable => "Yield not available",
+            SoroSusuError::YieldAlreadyClaimed => "Yield already claimed",
+            SoroSusuError::InvalidYieldAmount => "Invalid yield amount",
+            SoroSusuError::HarvestFailed => "Yield harvest failed",
+            SoroSusuError::BatchHarvestInProgress => "Batch harvest in progress",
+
+            // Recovery and dispute errors
+            SoroSusuError::RecoveryNotProposed => "Recovery not proposed",
+            SoroSusuError::RecoveryAlreadyProposed => "Recovery already proposed",
+            SoroSusuError::RecoveryNotConsensus => "Recovery consensus not reached",
+            SoroSusuError::RecoveryFailed => "Recovery failed",
+            SoroSusuError::InvalidRecoveryAddress => "Invalid recovery address",
+            SoroSusuError::RecoveryWindowExpired => "Recovery window expired",
+            SoroSusuError::DisputeNotFound => "Dispute not found",
+            SoroSusuError::DisputeAlreadyExists => "Dispute already exists",
+            SoroSusuError::DisputeNotActive => "Dispute is not active",
+            SoroSusuError::DisputeResolved => "Dispute is already resolved",
+            SoroSusuError::InvalidDisputeAmount => "Invalid dispute amount",
+            SoroSusuError::JurorNotSelected => "Juror not selected",
+            SoroSusuError::VotingNotActive => "Voting is not active",
+            SoroSusuError::VotingAlreadyActive => "Voting is already active",
+            SoroSusuError::VotingCompleted => "Voting is completed",
+            SoroSusuError::InvalidVote => "Invalid vote",
+
+            // Lending market errors
+            SoroSusuError::LendingMarketNotInitialized => "Lending market not initialized",
+            SoroSusuError::LendingMarketDisabled => "Lending market is disabled",
+            SoroSusuError::LendingMarketEmergencyMode => "Lending market in emergency mode",
+            SoroSusuError::PoolNotFound => "Lending pool not found",
+            SoroSusuError::PoolNotActive => "Lending pool is not active",
+            SoroSusuError::PoolAlreadyExists => "Lending pool already exists",
+            SoroSusuError::InsufficientPoolLiquidity => "Insufficient pool liquidity",
+            SoroSusuError::InvalidLiquidityAmount => "Invalid liquidity amount",
+            SoroSusuError::PositionNotFound => "Lending position not found",
+            SoroSusuError::PositionNotActive => "Lending position is not active",
+            SoroSusuError::LoanAlreadyRepaid => "Loan already repaid",
+            SoroSusuError::InvalidLoanAmount => "Invalid loan amount",
+            SoroSusuError::InvalidLtvRatio => "Invalid LTV ratio",
+            SoroSusuError::LtvRatioExceeded => "LTV ratio exceeded",
+            SoroSusuError::MinLendingAmount => "Amount below minimum lending amount",
+            SoroSusuError::ScheduleNotFound => "Repayment schedule not found",
+            SoroSusuError::EmergencyLoanNotFound => "Emergency loan not found",
+            SoroSusuError::EmergencyLoanNotActive => "Emergency loan is not active",
+            SoroSusuError::VotingPeriodEnded => "Voting period has ended",
+            SoroSusuError::QuorumNotMet => "Quorum not met",
+
+            // Yield and strategy errors
+            SoroSusuError::YieldStrategyNotFound => "Yield strategy not found",
+            SoroSusuError::YieldStrategyNotActive => "Yield strategy is not active",
+            SoroSusuError::InvalidYieldStrategy => "Invalid yield strategy",
+            SoroSusuError::YieldOracleError => "Yield oracle error",
+            SoroSusuError::CircuitBreakerTriggered => "Circuit breaker triggered",
+            SoroSusuError::YieldAllocationFailed => "Yield allocation failed",
+            SoroSusuError::InvalidYieldAllocation => "Invalid yield allocation",
+            SoroSusuError::BridgeAdapterError => "Bridge adapter error",
+            SoroSusuError::SlippageExceeded => "Slippage exceeded",
+            SoroSusuError::PriceFeedError => "Price feed error",
+            SoroSusuError::InvalidPriceData => "Invalid price data",
+            SoroSusuError::YieldCalculationError => "Yield calculation error",
+
+            // Security and compliance errors
+            SoroSusuError::ReentrancyDetected => "Reentrancy attack detected",
+            SoroSusuError::Paused => "Contract is paused",
+            SoroSusuError::NotPaused => "Contract is not paused",
+            SoroSusuError::EmergencyMode => "Contract in emergency mode",
+            SoroSusuError::Blacklisted => "Address is blacklisted",
+            SoroSusuError::Sanctioned => "Address is sanctioned",
+            SoroSusuError::ComplianceFailed => "Compliance check failed",
+            SoroSusuError::AmlViolation => "AML violation detected",
+            SoroSusuError::KycRequired => "KYC verification required",
+            SoroSusuError::TaxWithholdingFailed => "Tax withholding failed",
+            SoroSusuError::InvalidTaxConfiguration => "Invalid tax configuration",
+            SoroSusuError::TaxExemptionInvalid => "Invalid tax exemption",
+            SoroSusuError::AuditEntryMissing => "Audit entry missing",
+            SoroSusuError::TrustlineMissing => "Trustline missing",
+            SoroSusuError::AnchorIntegrationError => "Anchor integration error",
+
+            // Technical and system errors
+            SoroSusuError::ContractNotInitialized => "Contract not initialized",
+            SoroSusuError::AdminNotSet => "Admin not set",
+            SoroSusuError::InvalidAdmin => "Invalid admin",
+            SoroSusuError::ConfigurationError => "Configuration error",
+            SoroSusuError::UpgradeFailed => "Contract upgrade failed",
+            SoroSusuError::MigrationFailed => "Data migration failed",
+            SoroSusuError::BackupFailed => "Backup failed",
+            SoroSusuError::RestoreFailed => "Restore failed",
+            SoroSusuError::NetworkError => "Network error",
+            SoroSusuError::GasLimitExceeded => "Gas limit exceeded",
+            SoroSusuError::ExecutionTimeout => "Execution timeout",
+            SoroSusuError::InternalError => "Internal error occurred",
+            SoroSusuError::DeprecatedFunction => "Function is deprecated",
+            SoroSusuError::FeatureNotEnabled => "Feature not enabled",
+            SoroSusuError::InvalidChain => "Invalid blockchain",
+            SoroSusuError::VersionMismatch => "Version mismatch",
+        }
+    }
+
+    /// Get the u32 error code for frontend parsing
+    pub fn code(&self) -> u32 {
+        *self as u32
+    }
+
+    /// Convert from u32 code back to error (for frontend parsing)
+    pub fn from_code(code: u32) -> Option<Self> {
+        match code {
+            // General errors
+            1000 => Some(SoroSusuError::Unauthorized),
+            1001 => Some(SoroSusuError::InvalidInput),
+            1002 => Some(SoroSusuError::Overflow),
+            1003 => Some(SoroSusuError::NotFound),
+            1004 => Some(SoroSusuError::AlreadyExists),
+            1005 => Some(SoroSusuError::InsufficientBalance),
+            1006 => Some(SoroSusuError::InvalidState),
+            1007 => Some(SoroSusuError::ArithmeticError),
+            1008 => Some(SoroSusuError::DivisionByZero),
+            1009 => Some(SoroSusuError::InvalidAddress),
+            1010 => Some(SoroSusuError::TimestampError),
+            1011 => Some(SoroSusuError::StorageError),
+            1012 => Some(SoroSusuError::SerializationError),
+            1013 => Some(SoroSusuError::InvalidSignature),
+            1014 => Some(SoroSusuError::RateLimitExceeded),
+            1015 => Some(SoroSusuError::MaintenanceMode),
+
+            // Circle management errors
+            2000 => Some(SoroSusuError::CircleNotFound),
+            2001 => Some(SoroSusuError::CircleAlreadyExists),
+            2002 => Some(SoroSusuError::CircleIsFull),
+            2003 => Some(SoroSusuError::CircleNotActive),
+            2004 => Some(SoroSusuError::CircleAlreadyFinalized),
+            2005 => Some(SoroSusuError::CircleNotMatured),
+            2006 => Some(SoroSusuError::InvalidCircleDuration),
+            2007 => Some(SoroSusuError::MaxGroupSizeExceeded),
+            2008 => Some(SoroSusuError::CircleCompleted),
+            2009 => Some(SoroSusuError::CircleNotCompleted),
+            2010 => Some(SoroSusuError::InvalidContributionAmount),
+            2011 => Some(SoroSusuError::InvalidInsuranceFee),
+            2012 => Some(SoroSusuError::InvalidMaxMembers),
+            2013 => Some(SoroSusuError::CircleDrained),
+            2014 => Some(SoroSusuError::CircleNotDrained),
+
+            // Member management errors
+            3000 => Some(SoroSusuError::MemberNotFound),
+            3001 => Some(SoroSusuError::MemberAlreadyExists),
+            3002 => Some(SoroSusuError::MemberNotActive),
+            3003 => Some(SoroSusuError::MemberIndexOutOfBounds),
+            3004 => Some(SoroSusuError::MemberAlreadyPaid),
+            3005 => Some(SoroSusuError::MemberNotPaid),
+            3006 => Some(SoroSusuError::InvalidMemberStatus),
+            3007 => Some(SoroSusuError::MemberIneligible),
+            3008 => Some(SoroSusuError::MemberDefaulted),
+            3009 => Some(SoroSusuError::MemberNotDefaulted),
+            3010 => Some(SoroSusuError::TooManyMembers),
+            3011 => Some(SoroSusuError::InsufficientMembers),
+            3012 => Some(SoroSusuError::MemberNotRecipient),
+            3013 => Some(SoroSusuError::MemberAlreadyRecipient),
+
+            // Contribution and payment errors
+            4000 => Some(SoroSusuError::InvalidContribution),
+            4001 => Some(SoroSusuError::ContributionOverflow),
+            4002 => Some(SoroSusuError::InsufficientContribution),
+            4003 => Some(SoroSusuError::ContributionAlreadyMade),
+            4004 => Some(SoroSusuError::ContributionNotMade),
+            4005 => Some(SoroSusuError::InvalidRounds),
+            4006 => Some(SoroSusuError::ZeroRounds),
+            4007 => Some(SoroSusuError::ContributionPeriodClosed),
+            4008 => Some(SoroSusuError::ContributionPeriodOpen),
+            4009 => Some(SoroSusuError::PaymentFailed),
+            4010 => Some(SoroSusuError::InvalidPaymentAmount),
+            4011 => Some(SoroSusuError::PaymentAlreadyProcessed),
+            4012 => Some(SoroSusuError::PaymentNotDue),
+            4013 => Some(SoroSusuError::LateFeeApplicable),
+            4014 => Some(SoroSusuError::LateFeeNotApplicable),
+
+            // Payout and distribution errors
+            5000 => Some(SoroSusuError::NoRecipientSet),
+            5001 => Some(SoroSusuError::PayoutAlreadyDistributed),
+            5002 => Some(SoroSusuError::InsufficientPotBalance),
+            5003 => Some(SoroSusuError::InvalidPayoutAmount),
+            5004 => Some(SoroSusuError::PayoutFailed),
+            5005 => Some(SoroSusuError::DistributionFailed),
+            5006 => Some(SoroSusuError::InvalidDistributionRatio),
+            5007 => Some(SoroSusuError::YieldNotAvailable),
+            5008 => Some(SoroSusuError::YieldAlreadyClaimed),
+            5009 => Some(SoroSusuError::InvalidYieldAmount),
+            5010 => Some(SoroSusuError::HarvestFailed),
+            5011 => Some(SoroSusuError::BatchHarvestInProgress),
+
+            // Recovery and dispute errors
+            6000 => Some(SoroSusuError::RecoveryNotProposed),
+            6001 => Some(SoroSusuError::RecoveryAlreadyProposed),
+            6002 => Some(SoroSusuError::RecoveryNotConsensus),
+            6003 => Some(SoroSusuError::RecoveryFailed),
+            6004 => Some(SoroSusuError::InvalidRecoveryAddress),
+            6005 => Some(SoroSusuError::RecoveryWindowExpired),
+            6006 => Some(SoroSusuError::DisputeNotFound),
+            6007 => Some(SoroSusuError::DisputeAlreadyExists),
+            6008 => Some(SoroSusuError::DisputeNotActive),
+            6009 => Some(SoroSusuError::DisputeResolved),
+            6010 => Some(SoroSusuError::InvalidDisputeAmount),
+            6011 => Some(SoroSusuError::JurorNotSelected),
+            6012 => Some(SoroSusuError::VotingNotActive),
+            6013 => Some(SoroSusuError::VotingAlreadyActive),
+            6014 => Some(SoroSusuError::VotingCompleted),
+            6015 => Some(SoroSusuError::InvalidVote),
+
+            // Lending market errors
+            7000 => Some(SoroSusuError::LendingMarketNotInitialized),
+            7001 => Some(SoroSusuError::LendingMarketDisabled),
+            7002 => Some(SoroSusuError::LendingMarketEmergencyMode),
+            7003 => Some(SoroSusuError::PoolNotFound),
+            7004 => Some(SoroSusuError::PoolNotActive),
+            7005 => Some(SoroSusuError::PoolAlreadyExists),
+            7006 => Some(SoroSusuError::InsufficientPoolLiquidity),
+            7007 => Some(SoroSusuError::InvalidLiquidityAmount),
+            7008 => Some(SoroSusuError::PositionNotFound),
+            7009 => Some(SoroSusuError::PositionNotActive),
+            7010 => Some(SoroSusuError::LoanAlreadyRepaid),
+            7011 => Some(SoroSusuError::InvalidLoanAmount),
+            7012 => Some(SoroSusuError::InvalidLtvRatio),
+            7013 => Some(SoroSusuError::LtvRatioExceeded),
+            7014 => Some(SoroSusuError::MinLendingAmount),
+            7015 => Some(SoroSusuError::ScheduleNotFound),
+            7016 => Some(SoroSusuError::EmergencyLoanNotFound),
+            7017 => Some(SoroSusuError::EmergencyLoanNotActive),
+            7018 => Some(SoroSusuError::VotingPeriodEnded),
+            7019 => Some(SoroSusuError::QuorumNotMet),
+
+            // Yield and strategy errors
+            8000 => Some(SoroSusuError::YieldStrategyNotFound),
+            8001 => Some(SoroSusuError::YieldStrategyNotActive),
+            8002 => Some(SoroSusuError::InvalidYieldStrategy),
+            8003 => Some(SoroSusuError::YieldOracleError),
+            8004 => Some(SoroSusuError::CircuitBreakerTriggered),
+            8005 => Some(SoroSusuError::YieldAllocationFailed),
+            8006 => Some(SoroSusuError::InvalidYieldAllocation),
+            8007 => Some(SoroSusuError::BridgeAdapterError),
+            8008 => Some(SoroSusuError::SlippageExceeded),
+            8009 => Some(SoroSusuError::PriceFeedError),
+            8010 => Some(SoroSusuError::InvalidPriceData),
+            8011 => Some(SoroSusuError::YieldCalculationError),
+
+            // Security and compliance errors
+            9000 => Some(SoroSusuError::ReentrancyDetected),
+            9001 => Some(SoroSusuError::Paused),
+            9002 => Some(SoroSusuError::NotPaused),
+            9003 => Some(SoroSusuError::EmergencyMode),
+            9004 => Some(SoroSusuError::Blacklisted),
+            9005 => Some(SoroSusuError::Sanctioned),
+            9006 => Some(SoroSusuError::ComplianceFailed),
+            9007 => Some(SoroSusuError::AmlViolation),
+            9008 => Some(SoroSusuError::KycRequired),
+            9009 => Some(SoroSusuError::TaxWithholdingFailed),
+            9010 => Some(SoroSusuError::InvalidTaxConfiguration),
+            9011 => Some(SoroSusuError::TaxExemptionInvalid),
+            9012 => Some(SoroSusuError::AuditEntryMissing),
+            9013 => Some(SoroSusuError::TrustlineMissing),
+            9014 => Some(SoroSusuError::AnchorIntegrationError),
+
+            // Technical and system errors
+            10000 => Some(SoroSusuError::ContractNotInitialized),
+            10001 => Some(SoroSusuError::AdminNotSet),
+            10002 => Some(SoroSusuError::InvalidAdmin),
+            10003 => Some(SoroSusuError::ConfigurationError),
+            10004 => Some(SoroSusuError::UpgradeFailed),
+            10005 => Some(SoroSusuError::MigrationFailed),
+            10006 => Some(SoroSusuError::BackupFailed),
+            10007 => Some(SoroSusuError::RestoreFailed),
+            10008 => Some(SoroSusuError::NetworkError),
+            10009 => Some(SoroSusuError::GasLimitExceeded),
+            10010 => Some(SoroSusuError::ExecutionTimeout),
+            10011 => Some(SoroSusuError::InternalError),
+            10012 => Some(SoroSusuError::DeprecatedFunction),
+            10013 => Some(SoroSusuError::FeatureNotEnabled),
+            10014 => Some(SoroSusuError::InvalidChain),
+            10015 => Some(SoroSusuError::VersionMismatch),
+
+            _ => None,
+        }
+    }
+}
+
+/// Result type alias for SoroSusu operations
+pub type SoroSusuResult<T> = Result<T, SoroSusuError>;
+
+/// Convert SoroSusuError to Soroban Error for contract return
+impl From<SoroSusuError> for Error {
+    fn from(error: SoroSusuError) -> Self {
+        Error::from_contract_error(error.code())
+    }
+}
+
+/// Convert Soroban Error to SoroSusuError (for error handling)
+impl From<Error> for SoroSusuError {
+    fn from(error: Error) -> Self {
+        // Try to extract contract error code
+        if let Some(contract_code) = error.to_contract_error() {
+            if let Some(sorosusu_error) = SoroSusuError::from_code(contract_code) {
+                return sorosusu_error;
+            }
+        }
+        
+        // Fallback to generic errors based on error type
+        match error {
+            Error::FromContractError(_) => SoroSusuError::InternalError,
+            Error::FromContractErrorWithDetails { .. } => SoroSusuError::InternalError,
+            Error::HostError(_) => SoroSusuError::NetworkError,
+            Error::ContextError(_) => SoroSusuError::InvalidState,
+            Error::WasmVmError(_) => SoroSusuError::InternalError,
+            Error::StorageError(_) => SoroSusuError::StorageError,
+            Error::ObjectError(_) => SoroSusuError::SerializationError,
+            Error::CryptoError(_) => SoroSusuError::InvalidSignature,
+            Error::EventsError(_) => SoroSusuError::InternalError,
+            Error::BudgetError(_) => SoroSusuError::GasLimitExceeded,
+            Error::VmError(_) => SoroSusuError::InternalError,
+            Error::IoError(_) => SoroSusuError::StorageError,
+            Error::Infallible => SoroSusuError::InternalError,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_codes() {
+        assert_eq!(SoroSusuError::Unauthorized.code(), 1000);
+        assert_eq!(SoroSusuError::CircleNotFound.code(), 2000);
+        assert_eq!(SoroSusuError::MemberNotFound.code(), 3000);
+    }
+
+    #[test]
+    fn test_error_from_code() {
+        assert_eq!(SoroSusuError::from_code(1000), Some(SoroSusuError::Unauthorized));
+        assert_eq!(SoroSusuError::from_code(2000), Some(SoroSusuError::CircleNotFound));
+        assert_eq!(SoroSusuError::from_code(9999), None);
+    }
+
+    #[test]
+    fn test_human_readable_messages() {
+        assert_eq!(
+            SoroSusuError::CircleNotMatured.to_human_readable(),
+            "Circle has not matured yet"
+        );
+        assert_eq!(
+            SoroSusuError::Unauthorized.to_human_readable(),
+            "You are not authorized to perform this action"
+        );
+    }
+
+    #[test]
+    fn test_error_conversion() {
+        let sorosusu_error = SoroSusuError::CircleNotFound;
+        let soroban_error: Error = sorosusu_error.clone().into();
+        let converted_back: SoroSusuError = soroban_error.into();
+        
+        // Should preserve the error type if it's a contract error
+        match converted_back {
+            SoroSusuError::InternalError => {
+                // This is expected for non-contract errors
+            }
+            _ => {
+                // For contract errors, it should preserve the type
+                assert_eq!(converted_back.code(), sorosusu_error.code());
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@ use soroban_sdk::{
     Symbol, Vec, Bytes, BytesN,
 };
 
+pub mod errors;
+pub use errors::{SoroSusuError, SoroSusuResult};
+
 pub mod chat_metadata;
 pub mod dispute;
 pub mod yield_allocation_voting;
@@ -417,13 +420,13 @@ pub trait SoroSusuTrait {
         risk_tolerance: u32,
         grace_period: u64,
         late_fee_bps: u32,
-    ) -> u64;
+    ) -> SoroSusuResult<u64>;
 
     // Join an existing circle
-    fn join_circle(env: Env, user: Address, circle_id: u64);
+    fn join_circle(env: Env, user: Address, circle_id: u64, shares: u32, guarantor: Option<Address>) -> SoroSusuResult<()>;
 
     // Make a batch deposit for one or more rounds.
-    fn deposit(env: Env, user: Address, circle_id: u64, rounds: u32);
+    fn deposit(env: Env, user: Address, circle_id: u64, rounds: u32) -> SoroSusuResult<()>;
 
     // Late contribution with fee (pay after deadline but within grace period)
     fn late_contribution(env: Env, user: Address, circle_id: u64);
@@ -914,10 +917,10 @@ impl SoroSusuTrait for SoroSusu {
         risk_tolerance: u32,
         grace_period: u64,
         late_fee_bps: u32,
-    ) -> u64 {
+    ) -> SoroSusuResult<u64> {
         // Issue #321: Enforce MAX_CYCLE_DURATION cap to prevent overflow exploits.
         if cycle_duration > MAX_CYCLE_DURATION {
-            panic!("cycle_duration exceeds MAX_CYCLE_DURATION");
+            return Err(SoroSusuError::InvalidCircleDuration);
         }
 
         // 1. Get the current Circle Count
@@ -1904,9 +1907,9 @@ pub trait SoroSusuTrait {
     fn get_gas_buffer_balance(env: Env, circle_id: u64) -> i128;
 
     // NEW: Payout functions with gas buffer support
-    fn distribute_payout(env: Env, caller: Address, circle_id: u64);
-    fn trigger_payout(env: Env, admin: Address, circle_id: u64);
-    fn finalize_round(env: Env, creator: Address, circle_id: u64);
+    fn distribute_payout(env: Env, caller: Address, circle_id: u64) -> SoroSusuResult<()>;
+    fn trigger_payout(env: Env, admin: Address, circle_id: u64) -> SoroSusuResult<()>;
+    fn finalize_round(env: Env, creator: Address, circle_id: u64) -> SoroSusuResult<()>;
 
     // Issue #406: Anti-Collusion Multi-Sig Round Skipping
     fn configure_multisig_round_skip(env: Env, admin: Address, circle_id: u64, config: MultiSigConfig);
@@ -2180,11 +2183,11 @@ fn calculate_rollover_bonus(env: &Env, circle_id: u64, fee_percentage_bps: u32) 
     bonus_amount
 }
 
-fn get_member_address_by_index(circle: &CircleInfo, index: u32) -> Address {
+fn get_member_address_by_index(circle: &CircleInfo, index: u32) -> SoroSusuResult<Address> {
     if index >= circle.member_count {
-        panic!("Member index out of bounds");
+        return Err(SoroSusuError::MemberIndexOutOfBounds);
     }
-    circle.member_addresses.get(index).unwrap()
+    Ok(circle.member_addresses.get(index).unwrap())
 }
 
 /// Helper function to find a member's index in the Vec by address.
@@ -2269,10 +2272,10 @@ fn count_active_members(env: &Env, circle: &CircleInfo) -> u32 {
     members.iter().filter(|m| m.status == MemberStatus::Active).count() as u32
 }
 
-fn apply_recovery_if_consensus(env: &Env, actor: &Address, circle_id: u64, circle: &mut CircleInfo) {
+fn apply_recovery_if_consensus(env: &Env, actor: &Address, circle_id: u64, circle: &mut CircleInfo) -> SoroSusuResult<()> {
     let active_members = count_active_members(env, circle);
     if active_members == 0 {
-        panic!("No active members");
+        return Err(SoroSusuError::InsufficientMembers);
     }
 
     let votes = circle.recovery_votes_bitmap.count_ones();
@@ -2283,28 +2286,28 @@ fn apply_recovery_if_consensus(env: &Env, actor: &Address, circle_id: u64, circl
     let old_address = circle
         .recovery_old_address
         .clone()
-        .unwrap_or_else(|| panic!("No recovery proposal"));
+        .ok_or(SoroSusuError::RecoveryNotProposed)?;
     let new_address = circle
         .recovery_new_address
         .clone()
-        .unwrap_or_else(|| panic!("No recovery proposal"));
+        .ok_or(SoroSusuError::RecoveryNotProposed)?;
 
     // Load members Vec
     let mut members = load_members(env, circle_id);
     
     // Find old member in Vec
     let old_member_idx = find_member(&members, &old_address)
-        .unwrap_or_else(|| panic!("Old member not found"));
+        .ok_or(SoroSusuError::MemberNotFound)?;
     
     let old_member = members.get(old_member_idx).unwrap();
     
     if old_member.status != MemberStatus::Active {
-        panic!("Only active members can be recovered");
+        return Err(SoroSusuError::MemberNotActive);
     }
 
     // Check new address is not already a member
     if find_member(&members, &new_address).is_some() {
-        panic!("New address is already a member");
+        return Err(SoroSusuError::MemberAlreadyExists);
     }
 
     // Update member address in Vec
@@ -2343,6 +2346,7 @@ fn apply_recovery_if_consensus(env: &Env, actor: &Address, circle_id: u64, circl
     circle.recovery_votes_bitmap = 0;
 
     write_audit(env, actor, AuditAction::AdminAction, circle_id);
+    Ok(())
 }
 
 fn query_from_indexed_ids(
@@ -2352,10 +2356,10 @@ fn query_from_indexed_ids(
     end_time: u64,
     offset: u32,
     limit: u32,
-) -> Vec<AuditEntry> {
+) -> SoroSusuResult<Vec<AuditEntry>> {
     let mut output = Vec::new(env);
     if limit == 0 || start_time > end_time {
-        return output;
+        return Ok(output);
     }
 
     let bounded_limit = if limit > MAX_QUERY_LIMIT {
@@ -2371,7 +2375,7 @@ fn query_from_indexed_ids(
             .storage()
             .instance()
             .get(&DataKey::AuditEntry(id))
-            .unwrap_or_else(|| panic!("Audit entry missing"));
+            .ok_or(SoroSusuError::AuditEntryMissing)?;
 
         if entry.timestamp < start_time || entry.timestamp > end_time {
             continue;
@@ -2389,7 +2393,7 @@ fn query_from_indexed_ids(
         output.push_back(entry);
     }
 
-    output
+    Ok(output)
 }
 
 fn finalize_leniency_vote_internal(
@@ -2505,12 +2509,14 @@ fn create_circle(
     cycle_duration: u64,
     insurance_fee_bps: u32,
     nft_contract: Address,
-) -> u64 {
+) -> SoroSusuResult<u64> {
     creator.require_auth();
 
     // Validate insurance fee (cannot exceed 100%)
     if insurance_fee_bps > 10_000 {
-        panic!("Insurance fee cannot exceed 100%");
+        return Err(SoroSusuError::InvalidInsuranceFee);
+    }
+
     /// - `max_members`: Maximum number of members allowed (determines total rounds).
     /// - `token`: SEP-41 token contract address used for contributions and payouts.
     /// - `cycle_duration`: Seconds between rounds (e.g. `604800` = 1 week).
@@ -2538,7 +2544,7 @@ fn create_circle(
 
         // Validate insurance fee (cannot exceed 100%)
         if insurance_fee_bps > 10_000 {
-            panic!("Insurance fee cannot exceed 100%");
+            return Err(SoroSusuError::InvalidInsuranceFee);
         }
 
         // Get the current Circle Count
@@ -2608,28 +2614,28 @@ fn create_circle(
     /// - `"Group size limit exceeded"` — attempting to exceed MAX_GROUP_SIZE.
     /// - `"Already a member"` — `user` is already in the circle.
     /// - `"Shares must be 1 or 2"` — invalid `shares` value.
-    fn join_circle(env: Env, user: Address, circle_id: u64, shares: u32, guarantor: Option<Address>) {
+    fn join_circle(env: Env, user: Address, circle_id: u64, shares: u32, guarantor: Option<Address>) -> SoroSusuResult<()> {
         // Authorization: The user MUST sign this transaction
         user.require_auth();
 
         // Validate shares (must be 1 or 2)
         if shares != 1 && shares != 2 {
-            panic!("Shares must be 1 or 2");
+            return Err(SoroSusuError::InvalidInput);
         }
 
         // Check if the circle exists
         let mut circle: CircleInfo = env.storage().instance()
             .get(&DataKey::Circle(circle_id))
-            .unwrap_or_else(|| panic!("Circle not found"));
+            .ok_or(SoroSusuError::CircleNotFound)?;
 
         // Check if the circle is full
         if circle.member_count >= circle.max_members {
-            panic!("Circle is full");
+            return Err(SoroSusuError::CircleIsFull);
         }
 
         // Enforce MAX_GROUP_SIZE for Vec-based storage optimization
         if circle.member_count >= MAX_GROUP_SIZE {
-            panic!("Group size limit exceeded");
+            return Err(SoroSusuError::MaxGroupSizeExceeded);
         }
 
         // Load existing members Vec
@@ -2637,7 +2643,7 @@ fn create_circle(
 
         // Check if the user is already a member (O(n) scan acceptable for n ≤ 20)
         if find_member(&members, &user).is_some() {
-            panic!("Already a member");
+            return Err(SoroSusuError::MemberAlreadyExists);
         }
 
         // Add the user to the members list in CircleInfo (for backward compatibility)
@@ -2671,6 +2677,7 @@ fn create_circle(
 
         // Update the circle
         env.storage().instance().set(&DataKey::Circle(circle_id), &circle);
+        Ok(())
     }
 
     /// Submits the caller's contribution for one or more rounds.
@@ -2693,30 +2700,30 @@ fn create_circle(
     /// # Panics
     /// - `"Circle not found"` — `circle_id` does not exist.
     /// - `"Member not found"` — `user` is not a member of the circle.
-    fn deposit(env: Env, user: Address, circle_id: u64, rounds: u32) {
+    fn deposit(env: Env, user: Address, circle_id: u64, rounds: u32) -> SoroSusuResult<()> {
         user.require_auth();
         if rounds == 0 {
-            panic!("Rounds must be greater than zero");
+            return Err(SoroSusuError::ZeroRounds);
         }
 
         let circle: CircleInfo = env.storage().instance()
             .get(&DataKey::Circle(circle_id))
-            .unwrap_or_else(|| panic!("Circle not found"));
+            .ok_or(SoroSusuError::CircleNotFound)?;
 
         // Load members Vec
         let mut members = load_members(&env, circle_id);
 
         // Find and update member (O(n) scan acceptable for n ≤ 20)
         let member = get_member_mut(&mut members, &user)
-            .unwrap_or_else(|| panic!("Member not found"));
+            .ok_or(SoroSusuError::MemberNotFound)?;
 
         if member.status != MemberStatus::Active {
-            panic!("Member not active");
+            return Err(SoroSusuError::MemberNotActive);
         }
 
         let total_contribution = circle.contribution_amount
             .checked_mul(rounds as i128)
-            .unwrap_or_else(|| panic!("Contribution overflow"));
+            .ok_or(SoroSusuError::ContributionOverflow)?;
 
         // Start atomic transaction
         let tx_id = contribution_security::ContributionSecurityTrait::start_contribution_transaction(
@@ -2725,7 +2732,7 @@ fn create_circle(
             circle_id,
             total_contribution as u64,
             rounds,
-        ).unwrap_or_else(|e| panic!("Failed to start transaction: {:?}", e));
+        ).map_err(|e| SoroSusuError::InternalError)?;
 
         // Execute the token transfer
         let token_client = soroban_sdk::token::Client::new(&env, &circle.token);
@@ -2738,18 +2745,19 @@ fn create_circle(
 
         member_mut.contribution_count = member_mut.contribution_count
             .checked_add(rounds)
-            .unwrap_or_else(|| panic!("Contribution count overflow"));
+            .ok_or(SoroSusuError::ArithmeticError)?;
         member_mut.last_contribution_time = current_time;
 
         let contribution_bit = 1u64
             .checked_shl(member_mut.index)
-            .unwrap_or_else(|| panic!("Member index overflow"));
+            .ok_or(SoroSusuError::ArithmeticError)?;
         circle_mut.contribution_bitmap |= contribution_bit;
 
         // Save updated members Vec (single storage write)
         save_members(&env, circle_id, &members);
         env.storage().instance().set(&DataKey::Circle(circle_id), &circle);
         env.storage().instance().set(&DataKey::Deposit(circle_id, user), &true);
+        Ok(())
     }
 
 
@@ -2781,13 +2789,13 @@ fn create_circle(
     /// # Panics
     /// - `"Circle not found"` — `circle_id` does not exist.
     /// - `"No recipient set"` — no recipient is queued for this round.
-    fn distribute_payout(env: Env, caller: Address, circle_id: u64) {
+    fn distribute_payout(env: Env, caller: Address, circle_id: u64) -> SoroSusuResult<()> {
         caller.require_auth();
         let circle: CircleInfo = env.storage().instance()
             .get(&DataKey::Circle(circle_id))
-            .unwrap_or_else(|| panic!("Circle not found"));
+            .ok_or(SoroSusuError::CircleNotFound)?;
         let recipient = circle.current_pot_recipient.clone()
-            .unwrap_or_else(|| panic!("No recipient set"));
+            .ok_or(SoroSusuError::NoRecipientSet)?;
         let gross_payout = circle.contribution_amount * circle.member_count as i128;
         let token_client = soroban_sdk::token::Client::new(&env, &circle.token);
         token_client.transfer(&env.current_contract_address(), &recipient, &gross_payout);
@@ -2795,6 +2803,7 @@ fn create_circle(
             (soroban_sdk::Symbol::new(&env, "payout_distributed"), circle_id),
             (recipient, gross_payout),
         );
+        Ok(())
     }
 
     /// # Admin-Only: Trigger Payout for a Circle
@@ -2823,14 +2832,15 @@ fn create_circle(
     ///
     /// # Panics
     /// - `"Unauthorized: Only admin can trigger payout"` — caller is not admin.
-    fn trigger_payout(env: Env, admin: Address, circle_id: u64) {
+    fn trigger_payout(env: Env, admin: Address, circle_id: u64) -> SoroSusuResult<()> {
         let stored_admin: Address = env.storage().instance()
             .get(&DataKey::Admin)
-            .unwrap_or_else(|| panic!("Admin not set"));
+            .ok_or(SoroSusuError::AdminNotSet)?;
         if admin != stored_admin {
-            panic!("Unauthorized: Only admin can trigger payout");
+            return Err(SoroSusuError::Unauthorized);
         }
-        Self::distribute_payout(env, admin, circle_id);
+        Self::distribute_payout(env, admin, circle_id)?;
+        Ok(())
     }
 
     /// Closes the current round and advances the payout queue to the next recipient.
@@ -2846,31 +2856,31 @@ fn create_circle(
     /// - `"Only creator can finalize round"` — caller is not the circle creator.
     /// - `"Round already finalized"` — the round has already been closed.
     /// - `"No members in circle"` — the circle has no members.
-    fn finalize_round(env: Env, creator: Address, circle_id: u64) {
+    fn finalize_round(env: Env, creator: Address, circle_id: u64) -> SoroSusuResult<()> {
         creator.require_auth();
 
         // Check authorization (only creator can finalize)
         let mut circle: CircleInfo = env.storage().instance()
             .get(&DataKey::Circle(circle_id))
-            .unwrap_or_else(|| panic!("Circle not found"));
+            .ok_or(SoroSusuError::CircleNotFound)?;
 
         if creator != circle.creator {
-            panic!("Only creator can finalize round");
+            return Err(SoroSusuError::Unauthorized);
         }
 
         if circle.is_round_finalized {
-            panic!("Round already finalized");
+            return Err(SoroSusuError::CircleAlreadyFinalized);
         }
 
         if circle.member_count == 0 {
-            panic!("No members in circle");
+            return Err(SoroSusuError::InsufficientMembers);
         }
 
         // Determine next recipient (round-robin based on current_recipient_index)
         let next_recipient_index = circle.current_recipient_index % circle.member_count;
         let next_recipient: Address = env.storage().instance()
             .get(&DataKey::CircleMember(circle_id, next_recipient_index))
-            .unwrap_or_else(|| panic!("Member not found for next round"));
+            .ok_or(SoroSusuError::MemberNotFound)?;
 
         // Update circle state
         circle.is_round_finalized = true;
@@ -2890,6 +2900,7 @@ fn create_circle(
             (Symbol::new(&env, "Payout_Ready"), circle_id),
             (next_recipient, scheduled_time),
         );
+        Ok(())
     }
 
     // --- ISSUE #406: ANTI-COLLUSION MULTI-SIG ROUND SKIPPING IMPLEMENTATION ---
@@ -2904,27 +2915,27 @@ fn create_circle(
     /// # Panics
     /// * `"Unauthorized"` - Caller is not admin or circle creator
     /// * `"Invalid config"` - Configuration is invalid
-    fn configure_multisig_round_skip(env: Env, admin: Address, circle_id: u64, config: MultiSigConfig) {
+    fn configure_multisig_round_skip(env: Env, admin: Address, circle_id: u64, config: MultiSigConfig) -> SoroSusuResult<()> {
         admin.require_auth();
 
         // Verify authorization (admin or circle creator)
         let admin_address: Option<Address> = env.storage().instance().get(&DataKey::Admin);
         let circle: CircleInfo = env.storage().instance()
             .get(&DataKey::Circle(circle_id))
-            .unwrap_or_else(|| panic!("Circle not found"));
+            .ok_or(SoroSusuError::CircleNotFound)?;
 
         let is_authorized = admin_address.map_or(false, |addr| addr == admin) || circle.creator == admin;
         if !is_authorized {
-            panic!("Unauthorized");
+            return Err(SoroSusuError::Unauthorized);
         }
 
         // Validate configuration
         if config.required_approvals == 0 || config.required_approvals > config.authorized_approvers.len() as u32 {
-            panic!("Invalid config");
+            return Err(SoroSusuError::InvalidInput);
         }
 
         if config.approval_timeout == 0 {
-            panic!("Invalid config");
+            return Err(SoroSusuError::InvalidInput);
         }
 
         // Store configuration
@@ -2935,6 +2946,7 @@ fn create_circle(
             (Symbol::new(&env, "multisig_configured"), circle_id),
             (config.required_approvals, config.authorized_approvers.len()),
         );
+        Ok(())
     }
 
     /// Propose to skip a specific round with anti-collusion protection


### PR DESCRIPTION
- Add comprehensive error types in errors.rs
- Update core functions to return SoroSusuResult<T>
- Refactor create_circle, join_circle, deposit, distribute_payout, trigger_payout, finalize_round
- Replace panic! calls with proper error handling using ? operator
- Update trait function signatures to match new Result types
- Establish consistent error handling pattern across the codebase

Remaining work: ~50+ panic! calls still need refactoring in other functions